### PR TITLE
Add configuration to run on mybinder.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # GoNB - A Go Notebook Kernel for Jupyter
 
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/janpfeifer/gonb/HEAD?labpath=examples%2Ftutorial.ipynb)
+
 To quick start, see the very simple [**tutorial**](examples/tutorial.ipynb)! And
 [here live version in Google's Colab](https://colab.research.google.com/drive/1vUd3SSoOm2K6UQLnkJQursZZx4CaIT_1?usp=sharing)
 that one can interact with (make a copy first) -- if link doesn't work (Google Drive sharing publicly

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -eu
+
+GO_VERSION=1.20
+
+curl -sfL https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz | tar -xz
+
+export PATH=$PATH:$HOME/go/bin
+
+go version
+
+go install
+
+go install golang.org/x/tools/cmd/goimports@latest
+go install golang.org/x/tools/gopls@latest
+
+gonb --install

--- a/binder/start
+++ b/binder/start
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -eu
+
+export PATH=$PATH:$HOME/go/bin
+
+exec "$@"


### PR DESCRIPTION
https://mybinder.org/ is a free resource for running temporary custom compute environments with Jupyter.

This PR adds the [configuration files](https://repo2docker.readthedocs.io/en/latest/configuration/index.html) to allow this repository to be run

Example (links to this PR branch):
https://mybinder.org/v2/gh/manics/gonb/binder?labpath=examples%2Ftutorial.ipynb