### PR TITLE
Use standard Jupyter CSS color coding for error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/janpfeifer/gonb)](https://goreportcard.com/report/github.com/janpfeifer/gonb)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/janpfeifer/gonb/HEAD?labpath=examples%2Ftutorial.ipynb)
 
-## To quick start, see the very simple [**tutorial**](examples/tutorial.ipynb)!
+## For a quick start, see the very simple [**tutorial**](examples/tutorial.ipynb)!
 
 Go is a compiled language, but with very fast compilation, that allows one to use
 it in a REPL (Read-Eval-Print-Loop) fashion, by inserting a "Compile" step in the middle
@@ -26,6 +26,8 @@ There is also
 that one can interact with (make a copy first) -- if link doesn't work (Google Drive sharing publicly
 is odd), [download it from github](examples/google_colab_demo.ipynb) and upload it to Google's Colab.
 
+It also works in VSCode and Github's Codespaces. Just follow the installation below.
+
 # Installation
 
 The [**tutorial**](examples/tutorial.ipynb) explains, but in short:
@@ -37,7 +39,15 @@ $ go install golang.org/x/tools/gopls@latest
 $ gonb --install
 ```
 
+Or all in one line that can be copy&pasted:
+
+```
+go install github.com/janpfeifer/gonb@latest && go install golang.org/x/tools/cmd/goimports@latest && go install golang.org/x/tools/gopls@latest && gonb --install
+```
+
 And then (re-)start Jupyter.
+
+In Github's Codespace, if Jupyter is already started, restarting the docker is an easy way to restart Jupyter.
 
 # Rich display: HTML, Images, SVG, Videos, manipulating javascript, etc.
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GoNB Changelog
 
+## v0.3.7
+
+* Use standard Jupyter CSS color coding for error context -- should work on different themes (See #3).
+
 ## v0.3.6
 
 * Better handling of gopls dying.

--- a/goexec/errorcontext.go
+++ b/goexec/errorcontext.go
@@ -28,29 +28,34 @@ type errorLine struct {
 	Context    string // Context to display on a mouse-over window, only if HasContext == true.
 }
 
+// To check the standard Jupyter colors to choose from, see:
+// https://github.com/jupyterlab/jupyterlab/blob/master/packages/theme-light-extension/style/variables.css
 var templateErrorReport = template.Must(template.New("error_report").Parse(`
 <style>
 .gonb-error-location {
-	background: #f8f8e0; 
+	color: var(--jp-content-font-color0);
+	background: var(--jp-error-color2);  
 	border-radius: 3px;
 	border-style: dotted;
 	border-width: 1px;
-	border-color: black;
+	border-color: var(--jp-border-color2);
 }
 .gonb-error-location:hover {
 	border-width: 2px;
 	border-style: solid;
+	border-color: var(--jp-border-color2);
 }
 .gonb-error-context {
 	display: none;
 }
 .gonb-error-location:hover + .gonb-error-context {
+	color: var(--jp-content-font-color0);
+	background: var(--jp-dialog-background);  
 	border-radius: 3px;
 	border-style: solid;
 	border-width: 1px;
-	border-color: black;
+	border-color: var(--jp-border-color2);
 	display: block;
-	background: #e0e0e0;
 	white-space: pre;
 	font-family: monospace;
 }
@@ -58,6 +63,7 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 	border-radius: 3px;
 	border-style: dotted;
 	border-width: 1px;	
+	border-color: var(--jp-border-color2);
 	font-weight: bold;
 }
 </style>


### PR DESCRIPTION
Should work on different themes. See #3 

Tested on JupyterLab light and dark themes. Should work in VSCode and Github's Codespaces also.