### PR TITLE
Fixed CSS for VSCode/Github Codespaces #3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GoNB Changelog
 
+## v0.3.8
+
+* Fixed CSS for VSCode/Github Codespaces -- it doesn't play very well with Jupyter CSS.
+
 ## v0.3.7
 
 * Use standard Jupyter CSS color coding for error context -- should work on different themes (See #3).

--- a/goexec/errorcontext.go
+++ b/goexec/errorcontext.go
@@ -33,7 +33,6 @@ type errorLine struct {
 var templateErrorReport = template.Must(template.New("error_report").Parse(`
 <style>
 .gonb-error-location {
-	color: var(--jp-content-font-color0);
 	background: var(--jp-error-color2);  
 	border-radius: 3px;
 	border-style: dotted;
@@ -49,7 +48,6 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 	display: none;
 }
 .gonb-error-location:hover + .gonb-error-context {
-	color: var(--jp-content-font-color0);
 	background: var(--jp-dialog-background);  
 	border-radius: 3px;
 	border-style: solid;
@@ -185,7 +183,9 @@ func (s *State) readMainGo() (string, error) {
 	if err != nil {
 		return "", errors.Wrapf(err, "failed readMainGo()")
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close() // Ignoring error on closing file for reading.
+	}()
 	content, err := io.ReadAll(f)
 	if err != nil {
 		return "", errors.Wrapf(err, "failed readMainGo()")


### PR DESCRIPTION
Fixed CSS for VSCode/Github Codespaces. Issue #3 

I should have tested earlier.