### PR TITLE
Update to "%%" behavior with args

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * "%%" or "%main" now set the program arguments as well. This may reset previously configured parameters
   given by "%args", which breaks compatibility is some cases, hence the version number bump.
+* Added "UpdateHTML" and "UniqueID", to allow dynamically updated HTML content on the page.
 
 ## v0.3.9
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,10 @@
 # GoNB Changelog
 
+## v0.4.0
+
+* "%%" or "%main" now set the program arguments as well. This may reset previously configured parameters
+  given by "%args", which breaks compatibility is some cases, hence the version number bump.
+
 ## v0.3.9
 
 * Small Go Report Card fixes (https://goreportcard.com/report/github.com/janpfeifer/gonb)

--- a/goexec/composer.go
+++ b/goexec/composer.go
@@ -77,7 +77,7 @@ func (s *State) createGoFileFromLines(filePath string, lines []string, skipLines
 		var createdFuncMain bool
 		for ii, line := range lines {
 			line = strings.TrimRight(line, " ")
-			if line == "%main" || line == "%%" {
+			if strings.HasPrefix(line, "%main") || strings.HasPrefix(line, "%%") {
 				addEmptyLine()
 				addLine("func main() {", NoCursorLine, 0)
 				addLine("\tflag.Parse()", NoCursorLine, 0)

--- a/gonbui/gonbui.go
+++ b/gonbui/gonbui.go
@@ -2,6 +2,7 @@ package gonbui
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/gob"
 	"fmt"
 	"github.com/janpfeifer/gonb/gonbui/protocol"
@@ -123,4 +124,17 @@ func DisplaySVG(svg string) {
 	//	Data: map[protocol.MIMEType]any{protocol.MIMEImageSVG: svg},
 	//})
 	DisplayHTML(fmt.Sprintf("<div>%s</div>", svg))
+}
+
+// EmbedImageAsPNGSrc returns a string that can be used as in an HTML <img> tag, as its source (it's `src` field).
+// This simplifies embedding an image in HTML without requiring separate files. It embeds it as a PNG file
+// base64 encoded.
+func EmbedImageAsPNGSrc(img image.Image) (string, error) {
+	buf := &bytes.Buffer{}
+	err := png.Encode(buf, img)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to encode image as PNG")
+	}
+	encoded := base64.StdEncoding.EncodeToString(buf.Bytes())
+	return fmt.Sprintf("data:image/png;base64,%s", encoded), nil
 }

--- a/gonbui/protocol/protocol.go
+++ b/gonbui/protocol/protocol.go
@@ -27,6 +27,7 @@ type DisplayData struct {
 
 	// DisplayID is a "transient" (see doc) information about which id to display something. It's used to
 	// overwrite some previous content. So far tested only with HTML. A program should always generate
-	// unique IDs to start with, and then re-use them to update them.
+	// unique IDs to start with, and then re-use them to update them. If set, after the first time that it's
+	// used, it will trigger the use of the `update_display_data` as opposed to `display_data` message.
 	DisplayID string
 }

--- a/kernel/messages.go
+++ b/kernel/messages.go
@@ -347,6 +347,21 @@ func PublishDisplayData(msg Message, data Data) error {
 	})
 }
 
+// PublishUpdateDisplayData is like PublishDisplayData, but expects `transient.display_id` to be set, and that a
+// previous `display_data` has already created this id.
+func PublishUpdateDisplayData(msg Message, data Data) error {
+	// copy Data in a struct with appropriate json tags
+	return msg.Publish("update_display_data", struct {
+		Data      MIMEMap `json:"data"`
+		Metadata  MIMEMap `json:"metadata"`
+		Transient MIMEMap `json:"transient"`
+	}{
+		Data:      data.Data,
+		Metadata:  EnsureMIMEMap(data.Metadata),
+		Transient: EnsureMIMEMap(data.Transient),
+	})
+}
+
 // PublishDisplayDataWithHTML is a shortcut to PublishDisplayData for HTML content.
 func PublishDisplayDataWithHTML(msg Message, html string) error {
 	msgData := Data{


### PR DESCRIPTION
* "%%" or "%main" now set the program arguments as well. This may reset previously configured parameters
  given by "%args", which breaks compatibility is some cases, hence the version number bump.
* Added "UpdateHTML" and "UniqueID", to allow dynamically updated HTML content on the page.
* Fixed crash when auto-complete returns a nil structure.

