### PR TITLE
Improved error reporting

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -1,0 +1,25 @@
+// Package common holds functionality that is common to multiple other packages.
+package common
+
+// Set implements a Set for the key type T.
+type Set[T comparable] map[T]struct{}
+
+// MakeSet returns an empty Set of the given type. Size is optional, and if given
+// will reserve the expected size.
+func MakeSet[T comparable](size ...int) Set[T] {
+	if len(size) == 0 {
+		return make(Set[T])
+	}
+	return make(Set[T], size[0])
+}
+
+// Has returns true if Set s has the given key.
+func (s Set[T]) Has(key T) bool {
+	_, found := s[key]
+	return found
+}
+
+// Insert key into set.
+func (s Set[T]) Insert(key T) {
+	s[key] = struct{}{}
+}

--- a/common/common.go
+++ b/common/common.go
@@ -1,6 +1,8 @@
 // Package common holds functionality that is common to multiple other packages.
 package common
 
+import "sort"
+
 // Set implements a Set for the key type T.
 type Set[T comparable] map[T]struct{}
 
@@ -22,4 +24,15 @@ func (s Set[T]) Has(key T) bool {
 // Insert key into set.
 func (s Set[T]) Insert(key T) {
 	s[key] = struct{}{}
+}
+
+// SortedKeys enumerate keys from a string map and sort them.
+// TODO: make it for any key type.
+func SortedKeys[T any](m map[string]T) (keys []string) {
+	keys = make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return
 }

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -4,6 +4,7 @@ package dispatcher
 
 import (
 	"fmt"
+	. "github.com/janpfeifer/gonb/common"
 	"github.com/janpfeifer/gonb/goexec"
 	"github.com/janpfeifer/gonb/gonbui/protocol"
 	"github.com/janpfeifer/gonb/kernel"
@@ -163,7 +164,7 @@ func handleExecuteRequest(msg kernel.Message, goExec *goexec.State) error {
 	// Dispatch to various executors.
 	msg.Kernel().Interrupted.Store(false)
 	lines := strings.Split(code, "\n")
-	usedLines := make(map[int]bool)
+	usedLines := MakeSet[int]()
 	var executionErr error
 	if err := specialcmd.Parse(msg, goExec, true, lines, usedLines); err != nil {
 		executionErr = errors.WithMessagef(err, "executing special commands in cell")
@@ -210,14 +211,14 @@ func HandleInspectRequest(msg kernel.Message, goExec *goexec.State) error {
 	lines, cursorLine, cursorCol := kernel.JupyterToLinesAndCursor(code, cursorPos)
 
 	// Separate special commands from Go commands.
-	usedLines := make(map[int]bool)
+	usedLines := MakeSet[int]()
 	if err := specialcmd.Parse(msg, goExec, false, lines, usedLines); err != nil {
 		return errors.WithMessagef(err, "parsing special commands in cell")
 	}
 
 	// Get data contents for reply.
 	var data kernel.MIMEMap
-	if usedLines[cursorLine] {
+	if usedLines.Has(cursorLine) {
 		// If special command, use our help message as inspect content.
 		data = kernel.MIMEMap{protocol.MIMETextPlain: any(specialcmd.HelpMessage)}
 	} else {
@@ -281,12 +282,12 @@ func handleCompleteRequest(msg kernel.Message, goExec *goexec.State) (err error)
 	lines, cursorLine, cursorCol := kernel.JupyterToLinesAndCursor(code, cursorPos)
 
 	// Separate special commands from Go commands.
-	usedLines := make(map[int]bool)
+	usedLines := MakeSet[int]()
 	if err = specialcmd.Parse(msg, goExec, false, lines, usedLines); err != nil {
 		err = errors.WithMessagef(err, "parsing special commands in cell")
 		return
 	}
-	if usedLines[cursorLine] {
+	if usedLines.Has(cursorLine) {
 		// No auto-complete for special commands.
 		return
 	}

--- a/dispatcher/dispatcher.go
+++ b/dispatcher/dispatcher.go
@@ -171,7 +171,7 @@ func handleExecuteRequest(msg kernel.Message, goExec *goexec.State) error {
 	}
 	hasMoreToRun := len(usedLines) < len(lines)
 	if executionErr == nil && !msg.Kernel().Interrupted.Load() && hasMoreToRun {
-		executionErr = goExec.ExecuteCell(msg, lines, usedLines)
+		executionErr = goExec.ExecuteCell(msg, msg.Kernel().ExecCounter, lines, usedLines)
 	}
 
 	// Final execution result.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # GoNB Changelog
 
+## v0.5
+
+* TODO: Improved error reporting, including indication of line number in cell.
+* TODO: Parse error output of the execution of a cell, and if it contains a stack-trace, "enrich"
+  references to the cell code (add context, making it easy to point out where the stack-trace happened).
+* Generally improved code documentation for `goexec` package.
+
 ## v0.4.1
 
 * Added support for Mac installation.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ## v0.5
 
-* TODO: Improved error reporting, including indication of line number in cell.
-* TODO: Parse error output of the execution of a cell, and if it contains a stack-trace, "enrich"
-  references to the cell code (add context, making it easy to point out where the stack-trace happened).
-* Generally improved code documentation for `goexec` package.
+* Improved error reporting, including indication of line number in cell.
+* Parse error output of the execution of a cell, and if it contains a stack-trace, add a reference to the cell
+  code (cell id and line number).
+* Cleaned up, improved code documentation and testing for `goexec` package.
 
 ## v0.4.1
 

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -63,7 +63,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "781a15d2-469e-4c93-b45e-c18067787f97",
    "metadata": {},
    "outputs": [
@@ -96,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "1c73bb12-8e2e-49a8-ae72-60d2c022e25f",
    "metadata": {},
    "outputs": [],
@@ -118,7 +118,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "d1414e76-3fa9-4046-827b-e449cc638e81",
    "metadata": {},
    "outputs": [
@@ -149,7 +149,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 5,
    "id": "5549f231-4061-4ec7-9e1c-8ae56c7c82d7",
    "metadata": {},
    "outputs": [
@@ -179,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 6,
    "id": "2111a24e-2627-463a-b936-d8476ba69005",
    "metadata": {},
    "outputs": [
@@ -214,7 +214,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 7,
    "id": "cbfa0e91-0209-48f5-962e-fc43dbc6b5bb",
    "metadata": {},
    "outputs": [
@@ -260,7 +260,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 8,
    "id": "48c217c5-6712-496e-8281-1179a487ad08",
    "metadata": {},
    "outputs": [
@@ -293,7 +293,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 9,
    "id": "e5f298cd-a260-493c-9c59-dd3d79706116",
    "metadata": {},
    "outputs": [
@@ -301,7 +301,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "lastRenderTime=2.716363\n"
+      "lastRenderTime=0.940111\n"
      ]
     },
     {
@@ -359,7 +359,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 10,
    "id": "48d813a8-8d4e-4ab7-b374-10a73977ec7b",
    "metadata": {},
    "outputs": [
@@ -501,7 +501,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 11,
    "id": "1fda7399-ecb1-44c2-b05c-fb52d188822a",
    "metadata": {},
    "outputs": [
@@ -519,14 +519,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 12,
    "id": "6904a8ef-5a4c-412f-ad75-58910d933b76",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div><svg viewbox=\"0 0 640 480\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"640\" height=\"480\"><defs><marker markerWidth=\"2%\" markerHeight=\"2%\" id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\"><circle cy=\"5\" r=\"3\" fill=\"none\" stroke=\"black\" cx=\"5\"/></marker><marker markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\"><circle stroke=\"none\" cx=\"5\" cy=\"5\" r=\"3\" fill=\"black\"/></marker><marker markerHeight=\"2%\" id=\"square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\"><rect y=\"2\" width=\"6\" height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\"/></marker><marker viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\"><rect stroke=\"none\" x=\"2\" y=\"2\" width=\"6\" height=\"6\" fill=\"black\"/></marker></defs><g transform=\"translate(70 410 )scale(1 -1 )\" fill=\"none\" stroke=\"hsl(90, 47%, 65%)\" stroke-linecap=\"round\" stroke-width=\"1px\" marker-mid=\"url(#square)\" marker-end=\"url(#square)\" stroke-linejoin=\"round\" marker-start=\"url(#square)\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,6.800000e+00 L6.333333e+01,4.306667e+01 L1.166667e+02,7.933333e+01 L170,1.156000e+02 L2.233333e+02,1.518667e+02 L2.766667e+02,1.881333e+02 L330,2.244000e+02 L3.833333e+02,2.606667e+02 L4.366667e+02,2.969333e+02 L490,3.332000e+02 \"/></g><g transform=\"translate(70 410 )scale(1 -1 )\" fill=\"none\" stroke=\"hsl(301, 88%, 65%)\" stroke-linecap=\"round\" stroke-width=\"3.14px\" stroke-linejoin=\"round\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,6.800000e+00 C1.888889e+01,6.875434e+00 4.555556e+01,7.018758e+00 6.333333e+01,7.252602e+00 C8.111111e+01,7.486446e+00 9.888889e+01,7.711993e+00 1.166667e+02,8.203066e+00 C1.344444e+02,8.694139e+00 1.522222e+02,9.167786e+00 1.700000e+02,1.019904e+01 C1.877778e+02,1.123029e+01 2.055556e+02,1.222495e+01 2.233333e+02,1.439059e+01 C2.411111e+02,1.655622e+01 2.588889e+02,1.864500e+01 2.766667e+02,2.319283e+01 C2.944444e+02,2.774066e+01 3.122222e+02,3.212711e+01 3.300000e+02,4.167755e+01 C3.477778e+02,5.122798e+01 3.655556e+02,6.043953e+01 3.833333e+02,8.049545e+01 C4.011111e+02,1.005514e+02 4.188889e+02,1.198956e+02 4.366667e+02,1.620130e+02 C4.544444e+02,2.041305e+02 4.811111e+02,3.046688e+02 4.900000e+02,3.332000e+02 \"/></g><g marker-start=\"url(#filled-circle)\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"3px\" marker-mid=\"url(#filled-circle)\" marker-end=\"url(#filled-circle)\" transform=\"translate(70 410 )scale(1 -1 )\" fill=\"none\" stroke=\"hsl(152, 76%, 65%)\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,1.863542e+02 C1.888889e+01,1.913775e+02 4.555556e+01,2.104195e+02 6.333333e+01,2.164942e+02 C8.111111e+01,2.225688e+02 9.888889e+01,2.120536e+02 1.166667e+02,2.228020e+02 C1.344444e+02,2.335503e+02 1.522222e+02,2.739828e+02 1.700000e+02,2.809843e+02 C1.877778e+02,2.879859e+02 2.055556e+02,2.678094e+02 2.233333e+02,2.648112e+02 C2.411111e+02,2.618129e+02 2.588889e+02,2.689812e+02 2.766667e+02,2.629950e+02 C2.944444e+02,2.570088e+02 3.122222e+02,2.288850e+02 3.300000e+02,2.288940e+02 C3.477778e+02,2.289029e+02 3.655556e+02,2.634800e+02 3.833333e+02,2.630486e+02 C4.011111e+02,2.626171e+02 4.188889e+02,2.439893e+02 4.366667e+02,2.263052e+02 C4.544444e+02,2.086212e+02 4.811111e+02,1.685045e+02 4.900000e+02,1.569443e+02 \"/></g><g transform=\"translate(70 410 )scale(1 -1 )\" fill=\"none\" stroke=\"black\" stroke-linecap=\"round\" stroke-linejoin=\"round\" stroke-width=\"2px\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,0 L10,-6 M6.333333e+01,0 L6.333333e+01,-6 M1.166667e+02,0 L1.166667e+02,-6 M170,0 L170,-6 M2.233333e+02,0 L2.233333e+02,-6 M2.766667e+02,0 L2.766667e+02,-6 M330,0 L330,-6 M3.833333e+02,0 L3.833333e+02,-6 M4.366667e+02,0 L4.366667e+02,-6 M490,0 L490,-6 \"/></g><g fill=\"black\" dominant-baseline=\"hanging\" stroke=\"black\" transform=\"translate(70 410 )scale(1 1 )\" font-style=\"normal\" stroke-linejoin=\"round\" font-size=\"12px\" text-anchor=\"middle\" font-family=\"sans-serif\" font-weight=\"normal\" stroke-width=\"2px\" stroke-linecap=\"round\"><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"10\" y=\"10\">1</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"6.333333e+01\" y=\"10\" dominant-baseline=\"hanging\">2</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"1.166667e+02\" y=\"10\" dominant-baseline=\"hanging\">3</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"10\" dominant-baseline=\"hanging\">4</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.233333e+02\" y=\"10\" dominant-baseline=\"hanging\">5</text><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.766667e+02\" y=\"10\">6</text><text x=\"330\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">7</text><text x=\"3.833333e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">8</text><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"4.366667e+02\" y=\"10\">9</text><text x=\"490\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">10</text></g><g dominant-baseline=\"baseline\" font-style=\"normal\" text-anchor=\"middle\" fill=\"black\" stroke=\"black\" stroke-linecap=\"round\" stroke-width=\"2px\" font-weight=\"bold\" stroke-linejoin=\"round\" font-size=\"12px\" font-family=\"sans-serif\" transform=\"translate(70 410 )scale(1 1 )rotate(0 0 0 )\"><text vector-effect=\"non-scaling-stroke\" x=\"250\" y=\"-6\" dominant-baseline=\"baseline\" stroke=\"none\">X</text></g><g stroke-width=\"2px\" font-family=\"sans-serif\" dominant-baseline=\"baseline\" font-size=\"12px\" font-style=\"normal\" text-anchor=\"middle\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" fill=\"black\" stroke=\"black\" stroke-linejoin=\"round\" font-weight=\"bold\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L-6,2.472591e+01 M0,5.860766e+01 L-6,5.860766e+01 M0,9.248942e+01 L-6,9.248942e+01 M0,1.263712e+02 L-6,1.263712e+02 M0,1.602529e+02 L-6,1.602529e+02 M0,1.941347e+02 L-6,1.941347e+02 M0,2.280164e+02 L-6,2.280164e+02 M0,2.618982e+02 L-6,2.618982e+02 M0,2.957799e+02 L-6,2.957799e+02 M0,3.296617e+02 L-6,3.296617e+02 \"/></g><g font-family=\"sans-serif\" dominant-baseline=\"middle\" transform=\"translate(70 410 )scale(1 1 )\" font-size=\"12px\" stroke=\"black\" stroke-linecap=\"round\" stroke-width=\"2px\" font-style=\"normal\" text-anchor=\"end\" fill=\"black\" stroke-linejoin=\"round\" font-weight=\"normal\"><text y=\"-2.472591e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">1.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-5.860766e+01\" dominant-baseline=\"middle\">2.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-9.248942e+01\">4.0</text><text y=\"-1.263712e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">8.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.602529e+02\" dominant-baseline=\"middle\">16.0</text><text y=\"-1.941347e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">32.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.280164e+02\" dominant-baseline=\"middle\">64.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.618982e+02\">128.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.957799e+02\" dominant-baseline=\"middle\">256.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-3.296617e+02\">512.0</text></g><g font-family=\"sans-serif\" font-weight=\"bold\" stroke-width=\"2px\" font-style=\"normal\" text-anchor=\"middle\" font-size=\"12px\" fill=\"black\" dominant-baseline=\"hanging\" stroke=\"black\" stroke-linecap=\"round\" stroke-linejoin=\"round\" transform=\"translate(70 410 )scale(1 1 )rotate(-90 0 0 )\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"6\" dominant-baseline=\"hanging\">Y</text></g><g transform=\"translate(70 410 )scale(1 -1 )\" fill=\"black\" stroke=\"gray\" stroke-linecap=\"round\" dominant-baseline=\"hanging\" font-family=\"sans-serif\" stroke-linejoin=\"round\" font-size=\"12px\" font-style=\"normal\" text-anchor=\"middle\" stroke-width=\"0.5px\" font-weight=\"bold\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L500,2.472591e+01 M0,5.860766e+01 L500,5.860766e+01 M0,9.248942e+01 L500,9.248942e+01 M0,1.263712e+02 L500,1.263712e+02 M0,1.602529e+02 L500,1.602529e+02 M0,1.941347e+02 L500,1.941347e+02 M0,2.280164e+02 L500,2.280164e+02 M0,2.618982e+02 L500,2.618982e+02 M0,2.957799e+02 L500,2.957799e+02 M0,3.296617e+02 L500,3.296617e+02 \"/></g><g fill=\"none\" font-family=\"sans-serif\" stroke-linejoin=\"round\" text-anchor=\"middle\" font-size=\"12px\" font-style=\"normal\" stroke=\"black\" stroke-linecap=\"round\" dominant-baseline=\"hanging\" stroke-width=\"2px\" font-weight=\"bold\"><rect width=\"500\" height=\"340\" vector-effect=\"non-scaling-stroke\" x=\"70\" y=\"70\"/><g dominant-baseline=\"middle\" fill=\"black\" font-size=\"18px\"><text x=\"320\" y=\"35\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">A diagram of sorts 📊 📈</text></g></g></svg></div>"
+       "<div><svg style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"640\" height=\"480\" viewbox=\"0 0 640 480\"><defs><marker viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"circle\"><circle cy=\"5\" r=\"3\" fill=\"none\" stroke=\"black\" cx=\"5\"/></marker><marker markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\"><circle cx=\"5\" cy=\"5\" r=\"3\" fill=\"black\" stroke=\"none\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"square\" viewBox=\"0 0 10 10 \" refX=\"5\"><rect fill=\"none\" stroke=\"black\" x=\"2\" y=\"2\" width=\"6\" height=\"6\"/></marker><marker viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\"><rect y=\"2\" width=\"6\" height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\"/></marker></defs><g fill=\"none\" stroke-linejoin=\"round\" stroke=\"hsl(90, 47%, 65%)\" stroke-linecap=\"round\" marker-start=\"url(#square)\" marker-mid=\"url(#square)\" marker-end=\"url(#square)\" stroke-width=\"1px\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,6.800000e+00 L6.333333e+01,4.306667e+01 L1.166667e+02,7.933333e+01 L170,1.156000e+02 L2.233333e+02,1.518667e+02 L2.766667e+02,1.881333e+02 L330,2.244000e+02 L3.833333e+02,2.606667e+02 L4.366667e+02,2.969333e+02 L490,3.332000e+02 \"/></g><g stroke-linejoin=\"round\" stroke=\"hsl(301, 88%, 65%)\" stroke-width=\"3.14px\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" fill=\"none\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,6.800000e+00 C1.888889e+01,6.875434e+00 4.555556e+01,7.018758e+00 6.333333e+01,7.252602e+00 C8.111111e+01,7.486446e+00 9.888889e+01,7.711993e+00 1.166667e+02,8.203066e+00 C1.344444e+02,8.694139e+00 1.522222e+02,9.167786e+00 1.700000e+02,1.019904e+01 C1.877778e+02,1.123029e+01 2.055556e+02,1.222495e+01 2.233333e+02,1.439059e+01 C2.411111e+02,1.655622e+01 2.588889e+02,1.864500e+01 2.766667e+02,2.319283e+01 C2.944444e+02,2.774066e+01 3.122222e+02,3.212711e+01 3.300000e+02,4.167755e+01 C3.477778e+02,5.122798e+01 3.655556e+02,6.043953e+01 3.833333e+02,8.049545e+01 C4.011111e+02,1.005514e+02 4.188889e+02,1.198956e+02 4.366667e+02,1.620130e+02 C4.544444e+02,2.041305e+02 4.811111e+02,3.046688e+02 4.900000e+02,3.332000e+02 \"/></g><g stroke=\"hsl(152, 76%, 65%)\" stroke-width=\"3px\" stroke-linecap=\"round\" marker-start=\"url(#filled-circle)\" fill=\"none\" stroke-linejoin=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" marker-mid=\"url(#filled-circle)\" marker-end=\"url(#filled-circle)\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,2.772856e+02 C1.888889e+01,2.745811e+02 4.555556e+01,2.630049e+02 6.333333e+01,2.610586e+02 C8.111111e+01,2.591123e+02 9.888889e+01,2.673614e+02 1.166667e+02,2.656078e+02 C1.344444e+02,2.638542e+02 1.522222e+02,2.600074e+02 1.700000e+02,2.505371e+02 C1.877778e+02,2.410668e+02 2.055556e+02,2.045381e+02 2.233333e+02,2.087859e+02 C2.411111e+02,2.130337e+02 2.588889e+02,2.739783e+02 2.766667e+02,2.760237e+02 C2.944444e+02,2.780692e+02 3.122222e+02,2.476227e+02 3.300000e+02,2.210586e+02 C3.477778e+02,1.944946e+02 3.655556e+02,1.233720e+02 3.833333e+02,1.166393e+02 C4.011111e+02,1.099067e+02 4.188889e+02,1.573622e+02 4.366667e+02,1.806626e+02 C4.544444e+02,2.039629e+02 4.811111e+02,2.438116e+02 4.900000e+02,2.564414e+02 \"/></g><g stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" fill=\"none\" stroke-linejoin=\"round\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,0 L10,-6 M6.333333e+01,0 L6.333333e+01,-6 M1.166667e+02,0 L1.166667e+02,-6 M170,0 L170,-6 M2.233333e+02,0 L2.233333e+02,-6 M2.766667e+02,0 L2.766667e+02,-6 M330,0 L330,-6 M3.833333e+02,0 L3.833333e+02,-6 M4.366667e+02,0 L4.366667e+02,-6 M490,0 L490,-6 \"/></g><g font-style=\"normal\" font-weight=\"normal\" stroke-linejoin=\"round\" dominant-baseline=\"hanging\" text-anchor=\"middle\" stroke=\"black\" stroke-width=\"2px\" font-family=\"sans-serif\" font-size=\"12px\" fill=\"black\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"10\" y=\"10\" dominant-baseline=\"hanging\">1</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"6.333333e+01\">2</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"1.166667e+02\">3</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\">4</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.233333e+02\">5</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.766667e+02\" y=\"10\" dominant-baseline=\"hanging\">6</text><text x=\"330\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">7</text><text x=\"3.833333e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">8</text><text x=\"4.366667e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">9</text><text vector-effect=\"non-scaling-stroke\" x=\"490\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">10</text></g><g font-family=\"sans-serif\" font-size=\"12px\" font-style=\"normal\" font-weight=\"bold\" stroke=\"black\" dominant-baseline=\"baseline\" fill=\"black\" stroke-linejoin=\"round\" stroke-width=\"2px\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )rotate(0 0 0 )\" text-anchor=\"middle\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"250\" y=\"-6\" dominant-baseline=\"baseline\">X</text></g><g transform=\"translate(70 410 )scale(1 -1 )\" stroke-linejoin=\"round\" font-size=\"12px\" font-style=\"normal\" font-weight=\"bold\" stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" text-anchor=\"middle\" fill=\"black\" font-family=\"sans-serif\" dominant-baseline=\"baseline\"><path d=\"M0,2.472591e+01 L-6,2.472591e+01 M0,5.860766e+01 L-6,5.860766e+01 M0,9.248942e+01 L-6,9.248942e+01 M0,1.263712e+02 L-6,1.263712e+02 M0,1.602529e+02 L-6,1.602529e+02 M0,1.941347e+02 L-6,1.941347e+02 M0,2.280164e+02 L-6,2.280164e+02 M0,2.618982e+02 L-6,2.618982e+02 M0,2.957799e+02 L-6,2.957799e+02 M0,3.296617e+02 L-6,3.296617e+02 \" vector-effect=\"non-scaling-stroke\"/></g><g stroke-width=\"2px\" transform=\"translate(70 410 )scale(1 1 )\" text-anchor=\"end\" dominant-baseline=\"middle\" font-size=\"12px\" font-weight=\"normal\" stroke=\"black\" fill=\"black\" stroke-linejoin=\"round\" font-family=\"sans-serif\" font-style=\"normal\" stroke-linecap=\"round\"><text y=\"-2.472591e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">1.0</text><text x=\"-10\" y=\"-5.860766e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">2.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-9.248942e+01\" dominant-baseline=\"middle\">4.0</text><text y=\"-1.263712e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">8.0</text><text y=\"-1.602529e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">16.0</text><text y=\"-1.941347e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">32.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.280164e+02\" dominant-baseline=\"middle\">64.0</text><text x=\"-10\" y=\"-2.618982e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">128.0</text><text x=\"-10\" y=\"-2.957799e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">256.0</text><text x=\"-10\" y=\"-3.296617e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">512.0</text></g><g font-family=\"sans-serif\" font-size=\"12px\" font-style=\"normal\" dominant-baseline=\"hanging\" stroke-width=\"2px\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )rotate(-90 0 0 )\" text-anchor=\"middle\" fill=\"black\" stroke-linejoin=\"round\" font-weight=\"bold\" stroke=\"black\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"6\" dominant-baseline=\"hanging\">Y</text></g><g font-style=\"normal\" stroke=\"gray\" stroke-width=\"0.5px\" text-anchor=\"middle\" fill=\"black\" font-size=\"12px\" font-weight=\"bold\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" dominant-baseline=\"hanging\" stroke-linejoin=\"round\" font-family=\"sans-serif\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L500,2.472591e+01 M0,5.860766e+01 L500,5.860766e+01 M0,9.248942e+01 L500,9.248942e+01 M0,1.263712e+02 L500,1.263712e+02 M0,1.602529e+02 L500,1.602529e+02 M0,1.941347e+02 L500,1.941347e+02 M0,2.280164e+02 L500,2.280164e+02 M0,2.618982e+02 L500,2.618982e+02 M0,2.957799e+02 L500,2.957799e+02 M0,3.296617e+02 L500,3.296617e+02 \"/></g><g font-family=\"sans-serif\" stroke-width=\"2px\" stroke=\"black\" text-anchor=\"middle\" dominant-baseline=\"hanging\" stroke-linejoin=\"round\" font-size=\"12px\" font-style=\"normal\" font-weight=\"bold\" fill=\"none\" stroke-linecap=\"round\"><rect width=\"500\" height=\"340\" vector-effect=\"non-scaling-stroke\" x=\"70\" y=\"70\"/><g font-size=\"18px\" fill=\"black\" dominant-baseline=\"middle\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"320\" y=\"35\" dominant-baseline=\"middle\">A diagram of sorts 📊 📈</text></g></g></svg></div>"
       ]
      },
      "metadata": {},
@@ -593,7 +593,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 13,
    "id": "293ceefc-c50c-4817-98fe-5f15ee4d0754",
    "metadata": {
     "tags": []
@@ -609,7 +609,7 @@
     {
      "data": {
       "text/html": [
-       "<svg style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"1024\" height=\"400\" viewbox=\"0 0 1024 400\"><defs><marker id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><circle r=\"3\" fill=\"none\" stroke=\"black\" cx=\"5\" cy=\"5\"/></marker><marker markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\"><circle fill=\"black\" stroke=\"none\" cx=\"5\" cy=\"5\" r=\"3\"/></marker><marker markerWidth=\"2%\" markerHeight=\"2%\" id=\"square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\"><rect stroke=\"black\" x=\"2\" y=\"2\" width=\"6\" height=\"6\" fill=\"none\"/></marker><marker id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><rect height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\" y=\"2\" width=\"6\"/></marker></defs><g stroke-width=\"3.14px\" stroke-linecap=\"round\" stroke-linejoin=\"round\" transform=\"translate(64 336 )scale(1 -1 )\" fill=\"none\" stroke=\"hsl(198, 47%, 65%)\"><path vector-effect=\"non-scaling-stroke\" d=\"M0.000000e+00,1.360312e+02 C1.508418e+00,1.499049e+02 6.033670e+00,1.968203e+02 9.050505e+00,2.192736e+02 C1.206734e+01,2.417269e+02 1.508418e+01,2.621600e+02 1.810101e+01,2.707510e+02 C2.111785e+01,2.793420e+02 2.413468e+01,2.793693e+02 2.715152e+01,2.708197e+02 C3.016835e+01,2.622702e+02 3.318519e+01,2.418813e+02 3.620202e+01,2.194536e+02 C3.921886e+01,1.970259e+02 4.223569e+01,1.640012e+02 4.525253e+01,1.362537e+02 C4.826936e+01,1.085063e+02 5.128620e+01,7.544786e+01 5.430303e+01,5.296898e+01 C5.731987e+01,3.049010e+01 6.033670e+01,1.001293e+01 6.335354e+01,1.380483e+00 C6.637037e+01,-7.251970e+00 6.938721e+01,-7.333825e+00 7.240404e+01,1.174264e+00 C7.542088e+01,9.682353e+00 7.843771e+01,3.002705e+01 8.145455e+01,5.242902e+01 C8.447138e+01,7.483099e+01 8.748822e+01,1.078388e+02 9.050505e+01,1.355861e+02 C9.352189e+01,1.633334e+02 9.653872e+01,1.964086e+02 9.955556e+01,2.189130e+02 C1.025724e+02,2.414174e+02 1.055892e+02,2.619386e+02 1.086061e+02,2.706125e+02 C1.116229e+02,2.792864e+02 1.146397e+02,2.794228e+02 1.176566e+02,2.709562e+02 C1.206734e+02,2.624896e+02 1.236902e+02,2.421892e+02 1.267071e+02,2.198130e+02 C1.297239e+02,1.974367e+02 1.327407e+02,1.644460e+02 1.357576e+02,1.366989e+02 C1.387744e+02,1.089517e+02 1.417912e+02,7.585985e+01 1.448081e+02,5.332998e+01 C1.478249e+02,3.080011e+01 1.508418e+02,1.023488e+01 1.538586e+02,1.519623e+00 C1.568754e+02,-7.195632e+00 1.598923e+02,-7.386626e+00 1.629091e+02,1.038449e+00 C1.659259e+02,9.463524e+00 1.689428e+02,2.971965e+01 1.719596e+02,5.207007e+01 C1.749764e+02,7.442050e+01 1.779933e+02,1.073941e+02 1.810101e+02,1.351410e+02 C1.840269e+02,1.628879e+02 1.870438e+02,1.959963e+02 1.900606e+02,2.185516e+02 C1.930774e+02,2.411069e+02 1.960943e+02,2.617161e+02 1.991111e+02,2.704727e+02 C2.021279e+02,2.792293e+02 2.051448e+02,2.794749e+02 2.081616e+02,2.710914e+02 C2.111785e+02,2.627078e+02 2.141953e+02,2.424960e+02 2.172121e+02,2.201715e+02 C2.202290e+02,1.978469e+02 2.232458e+02,1.648906e+02 2.262626e+02,1.371440e+02 C2.292795e+02,1.093973e+02 2.322963e+02,7.627244e+01 2.353131e+02,5.369180e+01 C2.383300e+02,3.111115e+01 2.413468e+02,1.045806e+01 2.443636e+02,1.660091e+00 C2.473805e+02,-7.137881e+00 2.503973e+02,-7.438012e+00 2.534141e+02,9.039661e-01 C2.564310e+02,9.245944e+00 2.594478e+02,2.941330e+01 2.624646e+02,5.171196e+01 C2.654815e+02,7.401061e+01 2.684983e+02,1.069497e+02 2.715152e+02,1.346959e+02 C2.745320e+02,1.624421e+02 2.775488e+02,1.955834e+02 2.805657e+02,2.181894e+02 C2.835825e+02,2.407953e+02 2.865993e+02,2.614923e+02 2.896162e+02,2.703316e+02 C2.926330e+02,2.791709e+02 2.956498e+02,2.795256e+02 2.986667e+02,2.712252e+02 C3.016835e+02,2.629248e+02 3.047003e+02,2.428019e+02 3.077172e+02,2.205292e+02 C3.107340e+02,1.982565e+02 3.137508e+02,1.653348e+02 3.167677e+02,1.375890e+02 C3.197845e+02,1.098432e+02 3.228013e+02,7.668562e+01 3.258182e+02,5.405442e+01 C3.288350e+02,3.142323e+01 3.318519e+02,1.068249e+01 3.348687e+02,1.801885e+00 C3.378855e+02,-7.078717e+00 3.409024e+02,-7.487981e+00 3.439192e+02,7.708167e-01 C3.469360e+02,9.029615e+00 3.499529e+02,2.910801e+01 3.529697e+02,5.135467e+01 C3.559865e+02,7.360134e+01 3.590034e+02,1.065055e+02 3.620202e+02,1.342508e+02 C3.650370e+02,1.619961e+02 3.680539e+02,1.951700e+02 3.710707e+02,2.178263e+02 C3.740875e+02,2.404827e+02 3.771044e+02,2.612672e+02 3.801212e+02,2.701891e+02 C3.831380e+02,2.791110e+02 3.861549e+02,2.795748e+02 3.891717e+02,2.713576e+02 C3.921886e+02,2.631405e+02 3.952054e+02,2.431066e+02 3.982222e+02,2.208860e+02 C4.012391e+02,1.986655e+02 4.042559e+02,1.657788e+02 4.072727e+02,1.380341e+02 C4.102896e+02,1.102894e+02 4.133064e+02,7.709938e+01 4.163232e+02,5.441786e+01 C4.193401e+02,3.173635e+01 4.223569e+02,1.090815e+01 4.253737e+02,1.945003e+00 C4.283906e+02,-7.018140e+00 4.314074e+02,-7.536535e+00 4.344242e+02,6.390024e-01 C4.374411e+02,8.814539e+00 4.404579e+02,2.880377e+01 4.434747e+02,5.099823e+01 C4.464916e+02,7.319268e+01 4.495084e+02,1.060617e+02 4.525253e+02,1.338058e+02 C4.555421e+02,1.615498e+02 4.585589e+02,1.947559e+02 4.615758e+02,2.174625e+02 C4.645926e+02,2.401691e+02 4.676094e+02,2.610410e+02 4.706263e+02,2.700453e+02 C4.736431e+02,2.790497e+02 4.766599e+02,2.796227e+02 4.796768e+02,2.714888e+02 C4.826936e+02,2.633549e+02 4.857104e+02,2.434103e+02 4.887273e+02,2.212421e+02 C4.917441e+02,1.990738e+02 4.947609e+02,1.662225e+02 4.977778e+02,1.384792e+02 C5.007946e+02,1.107358e+02 5.038114e+02,7.751373e+01 5.068283e+02,5.478211e+01 C5.098451e+02,3.205049e+01 5.128620e+02,1.113504e+01 5.158788e+02,2.089446e+00 C5.188956e+02,-6.956152e+00 5.219125e+02,-7.583671e+00 5.249293e+02,5.085242e-01 C5.279461e+02,8.600720e+00 5.309630e+02,2.850059e+01 5.339798e+02,5.064262e+01 C5.369966e+02,7.278465e+01 5.400135e+02,1.056182e+02 5.430303e+02,1.333607e+02 C5.460471e+02,1.611033e+02 5.490640e+02,1.943413e+02 5.520808e+02,2.170979e+02 C5.550976e+02,2.398544e+02 5.581145e+02,2.608134e+02 5.611313e+02,2.699002e+02 C5.641481e+02,2.789870e+02 5.671650e+02,2.796691e+02 5.701818e+02,2.716186e+02 C5.731987e+02,2.635681e+02 5.762155e+02,2.437130e+02 5.792323e+02,2.215973e+02 C5.822492e+02,1.994815e+02 5.852660e+02,1.666659e+02 5.882828e+02,1.389242e+02 C5.912997e+02,1.111825e+02 5.943165e+02,7.792865e+01 5.973333e+02,5.514715e+01 C6.003502e+02,3.236566e+01 6.033670e+02,1.136317e+01 6.063838e+02,2.235210e+00 C6.094007e+02,-6.892752e+00 6.124175e+02,-7.629390e+00 6.154343e+02,3.793837e-01 C6.184512e+02,8.388157e+00 6.214680e+02,2.819847e+01 6.244848e+02,5.028785e+01 C6.275017e+02,7.237724e+01 6.305185e+02,1.051749e+02 6.335354e+02,1.329157e+02 C6.365522e+02,1.606565e+02 6.395690e+02,1.939261e+02 6.425859e+02,2.167324e+02 C6.456027e+02,2.395388e+02 6.486195e+02,2.605847e+02 6.516364e+02,2.697538e+02 C6.546532e+02,2.789229e+02 6.576700e+02,2.797141e+02 6.606869e+02,2.717471e+02 C6.637037e+02,2.637800e+02 6.667205e+02,2.440146e+02 6.697374e+02,2.219516e+02 C6.727542e+02,1.998886e+02 6.757710e+02,1.671090e+02 6.787879e+02,1.393692e+02 C6.818047e+02,1.116294e+02 6.848215e+02,7.834414e+01 6.878384e+02,5.551300e+01 C6.908552e+02,3.268185e+01 6.938721e+02,1.159253e+01 6.968889e+02,2.382294e+00 C6.999057e+02,-6.827941e+00 7.029226e+02,-7.673691e+00 7.059394e+02,2.515819e-01 C7.089562e+02,8.176855e+00 7.119731e+02,2.789741e+01 7.149899e+02,4.993393e+01 C7.180067e+02,7.197046e+01 7.210236e+02,1.047320e+02 7.240404e+02,1.324707e+02 C7.270572e+02,1.602094e+02 7.300741e+02,1.935103e+02 7.330909e+02,2.163662e+02 C7.361077e+02,2.392221e+02 7.391246e+02,2.603547e+02 7.421414e+02,2.696061e+02 C7.451582e+02,2.788574e+02 7.481751e+02,2.797577e+02 7.511919e+02,2.718742e+02 C7.542088e+02,2.639907e+02 7.572256e+02,2.443151e+02 7.602424e+02,2.223051e+02 C7.632593e+02,2.002951e+02 7.662761e+02,1.675517e+02 7.692929e+02,1.398141e+02 C7.723098e+02,1.120766e+02 7.753266e+02,7.876021e+01 7.783434e+02,5.587964e+01 C7.813603e+02,3.299906e+01 7.843771e+02,1.182312e+01 7.873939e+02,2.530698e+00 C7.904108e+02,-6.761721e+00 7.934276e+02,-7.716574e+00 7.964444e+02,1.251203e-01 C7.994613e+02,7.966814e+00 8.024781e+02,2.759742e+01 8.054949e+02,4.958086e+01 C8.085118e+02,7.156431e+01 8.115286e+02,1.042894e+02 8.145455e+02,1.320258e+02 C8.175623e+02,1.597622e+02 8.205791e+02,1.930939e+02 8.235960e+02,2.159991e+02 C8.266128e+02,2.389043e+02 8.296296e+02,2.601235e+02 8.326465e+02,2.694570e+02 C8.356633e+02,2.787905e+02 8.386801e+02,2.797999e+02 8.416970e+02,2.720000e+02 C8.447138e+02,2.642001e+02 8.477306e+02,2.446146e+02 8.507475e+02,2.226577e+02 C8.537643e+02,2.007009e+02 8.567811e+02,1.679942e+02 8.597980e+02,1.402591e+02 C8.628148e+02,1.125240e+02 8.658316e+02,7.917684e+01 8.688485e+02,5.624706e+01 C8.718653e+02,3.331729e+01 8.748822e+02,1.205493e+01 8.778990e+02,2.680419e+00 C8.809158e+02,-6.694092e+00 8.839327e+02,-7.758038e+00 8.869495e+02,0.000000e+00 C8.899663e+02,7.758038e+00 8.944916e+02,4.102387e+01 8.960000e+02,4.922865e+01 \"/></g><g fill=\"none\" stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect x=\"64\" y=\"64\" width=\"896\" height=\"272\" vector-effect=\"non-scaling-stroke\"/><g dominant-baseline=\"middle\" text-anchor=\"middle\" fill=\"black\" font-family=\"sans-serif\" font-size=\"18px\" font-style=\"normal\" font-weight=\"bold\"><text x=\"512\" y=\"32\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">Animated Sine</text></g></g></svg>"
+       "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1024\" height=\"400\" viewbox=\"0 0 1024 400\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\"><defs><marker id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><circle cx=\"5\" cy=\"5\" r=\"3\" fill=\"none\" stroke=\"black\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\"><circle cx=\"5\" cy=\"5\" r=\"3\" fill=\"black\" stroke=\"none\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"square\" viewBox=\"0 0 10 10 \"><rect width=\"6\" height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\" y=\"2\"/></marker><marker id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><rect x=\"2\" y=\"2\" width=\"6\" height=\"6\" fill=\"black\" stroke=\"none\"/></marker></defs><g stroke-linejoin=\"round\" transform=\"translate(64 336 )scale(1 -1 )\" fill=\"none\" stroke=\"hsl(198, 47%, 65%)\" stroke-width=\"3.14px\" stroke-linecap=\"round\"><path vector-effect=\"non-scaling-stroke\" d=\"M0.000000e+00,1.360312e+02 C1.508418e+00,1.499049e+02 6.033670e+00,1.968203e+02 9.050505e+00,2.192736e+02 C1.206734e+01,2.417269e+02 1.508418e+01,2.621600e+02 1.810101e+01,2.707510e+02 C2.111785e+01,2.793420e+02 2.413468e+01,2.793693e+02 2.715152e+01,2.708197e+02 C3.016835e+01,2.622702e+02 3.318519e+01,2.418813e+02 3.620202e+01,2.194536e+02 C3.921886e+01,1.970259e+02 4.223569e+01,1.640012e+02 4.525253e+01,1.362537e+02 C4.826936e+01,1.085063e+02 5.128620e+01,7.544786e+01 5.430303e+01,5.296898e+01 C5.731987e+01,3.049010e+01 6.033670e+01,1.001293e+01 6.335354e+01,1.380483e+00 C6.637037e+01,-7.251970e+00 6.938721e+01,-7.333825e+00 7.240404e+01,1.174264e+00 C7.542088e+01,9.682353e+00 7.843771e+01,3.002705e+01 8.145455e+01,5.242902e+01 C8.447138e+01,7.483099e+01 8.748822e+01,1.078388e+02 9.050505e+01,1.355861e+02 C9.352189e+01,1.633334e+02 9.653872e+01,1.964086e+02 9.955556e+01,2.189130e+02 C1.025724e+02,2.414174e+02 1.055892e+02,2.619386e+02 1.086061e+02,2.706125e+02 C1.116229e+02,2.792864e+02 1.146397e+02,2.794228e+02 1.176566e+02,2.709562e+02 C1.206734e+02,2.624896e+02 1.236902e+02,2.421892e+02 1.267071e+02,2.198130e+02 C1.297239e+02,1.974367e+02 1.327407e+02,1.644460e+02 1.357576e+02,1.366989e+02 C1.387744e+02,1.089517e+02 1.417912e+02,7.585985e+01 1.448081e+02,5.332998e+01 C1.478249e+02,3.080011e+01 1.508418e+02,1.023488e+01 1.538586e+02,1.519623e+00 C1.568754e+02,-7.195632e+00 1.598923e+02,-7.386626e+00 1.629091e+02,1.038449e+00 C1.659259e+02,9.463524e+00 1.689428e+02,2.971965e+01 1.719596e+02,5.207007e+01 C1.749764e+02,7.442050e+01 1.779933e+02,1.073941e+02 1.810101e+02,1.351410e+02 C1.840269e+02,1.628879e+02 1.870438e+02,1.959963e+02 1.900606e+02,2.185516e+02 C1.930774e+02,2.411069e+02 1.960943e+02,2.617161e+02 1.991111e+02,2.704727e+02 C2.021279e+02,2.792293e+02 2.051448e+02,2.794749e+02 2.081616e+02,2.710914e+02 C2.111785e+02,2.627078e+02 2.141953e+02,2.424960e+02 2.172121e+02,2.201715e+02 C2.202290e+02,1.978469e+02 2.232458e+02,1.648906e+02 2.262626e+02,1.371440e+02 C2.292795e+02,1.093973e+02 2.322963e+02,7.627244e+01 2.353131e+02,5.369180e+01 C2.383300e+02,3.111115e+01 2.413468e+02,1.045806e+01 2.443636e+02,1.660091e+00 C2.473805e+02,-7.137881e+00 2.503973e+02,-7.438012e+00 2.534141e+02,9.039661e-01 C2.564310e+02,9.245944e+00 2.594478e+02,2.941330e+01 2.624646e+02,5.171196e+01 C2.654815e+02,7.401061e+01 2.684983e+02,1.069497e+02 2.715152e+02,1.346959e+02 C2.745320e+02,1.624421e+02 2.775488e+02,1.955834e+02 2.805657e+02,2.181894e+02 C2.835825e+02,2.407953e+02 2.865993e+02,2.614923e+02 2.896162e+02,2.703316e+02 C2.926330e+02,2.791709e+02 2.956498e+02,2.795256e+02 2.986667e+02,2.712252e+02 C3.016835e+02,2.629248e+02 3.047003e+02,2.428019e+02 3.077172e+02,2.205292e+02 C3.107340e+02,1.982565e+02 3.137508e+02,1.653348e+02 3.167677e+02,1.375890e+02 C3.197845e+02,1.098432e+02 3.228013e+02,7.668562e+01 3.258182e+02,5.405442e+01 C3.288350e+02,3.142323e+01 3.318519e+02,1.068249e+01 3.348687e+02,1.801885e+00 C3.378855e+02,-7.078717e+00 3.409024e+02,-7.487981e+00 3.439192e+02,7.708167e-01 C3.469360e+02,9.029615e+00 3.499529e+02,2.910801e+01 3.529697e+02,5.135467e+01 C3.559865e+02,7.360134e+01 3.590034e+02,1.065055e+02 3.620202e+02,1.342508e+02 C3.650370e+02,1.619961e+02 3.680539e+02,1.951700e+02 3.710707e+02,2.178263e+02 C3.740875e+02,2.404827e+02 3.771044e+02,2.612672e+02 3.801212e+02,2.701891e+02 C3.831380e+02,2.791110e+02 3.861549e+02,2.795748e+02 3.891717e+02,2.713576e+02 C3.921886e+02,2.631405e+02 3.952054e+02,2.431066e+02 3.982222e+02,2.208860e+02 C4.012391e+02,1.986655e+02 4.042559e+02,1.657788e+02 4.072727e+02,1.380341e+02 C4.102896e+02,1.102894e+02 4.133064e+02,7.709938e+01 4.163232e+02,5.441786e+01 C4.193401e+02,3.173635e+01 4.223569e+02,1.090815e+01 4.253737e+02,1.945003e+00 C4.283906e+02,-7.018140e+00 4.314074e+02,-7.536535e+00 4.344242e+02,6.390024e-01 C4.374411e+02,8.814539e+00 4.404579e+02,2.880377e+01 4.434747e+02,5.099823e+01 C4.464916e+02,7.319268e+01 4.495084e+02,1.060617e+02 4.525253e+02,1.338058e+02 C4.555421e+02,1.615498e+02 4.585589e+02,1.947559e+02 4.615758e+02,2.174625e+02 C4.645926e+02,2.401691e+02 4.676094e+02,2.610410e+02 4.706263e+02,2.700453e+02 C4.736431e+02,2.790497e+02 4.766599e+02,2.796227e+02 4.796768e+02,2.714888e+02 C4.826936e+02,2.633549e+02 4.857104e+02,2.434103e+02 4.887273e+02,2.212421e+02 C4.917441e+02,1.990738e+02 4.947609e+02,1.662225e+02 4.977778e+02,1.384792e+02 C5.007946e+02,1.107358e+02 5.038114e+02,7.751373e+01 5.068283e+02,5.478211e+01 C5.098451e+02,3.205049e+01 5.128620e+02,1.113504e+01 5.158788e+02,2.089446e+00 C5.188956e+02,-6.956152e+00 5.219125e+02,-7.583671e+00 5.249293e+02,5.085242e-01 C5.279461e+02,8.600720e+00 5.309630e+02,2.850059e+01 5.339798e+02,5.064262e+01 C5.369966e+02,7.278465e+01 5.400135e+02,1.056182e+02 5.430303e+02,1.333607e+02 C5.460471e+02,1.611033e+02 5.490640e+02,1.943413e+02 5.520808e+02,2.170979e+02 C5.550976e+02,2.398544e+02 5.581145e+02,2.608134e+02 5.611313e+02,2.699002e+02 C5.641481e+02,2.789870e+02 5.671650e+02,2.796691e+02 5.701818e+02,2.716186e+02 C5.731987e+02,2.635681e+02 5.762155e+02,2.437130e+02 5.792323e+02,2.215973e+02 C5.822492e+02,1.994815e+02 5.852660e+02,1.666659e+02 5.882828e+02,1.389242e+02 C5.912997e+02,1.111825e+02 5.943165e+02,7.792865e+01 5.973333e+02,5.514715e+01 C6.003502e+02,3.236566e+01 6.033670e+02,1.136317e+01 6.063838e+02,2.235210e+00 C6.094007e+02,-6.892752e+00 6.124175e+02,-7.629390e+00 6.154343e+02,3.793837e-01 C6.184512e+02,8.388157e+00 6.214680e+02,2.819847e+01 6.244848e+02,5.028785e+01 C6.275017e+02,7.237724e+01 6.305185e+02,1.051749e+02 6.335354e+02,1.329157e+02 C6.365522e+02,1.606565e+02 6.395690e+02,1.939261e+02 6.425859e+02,2.167324e+02 C6.456027e+02,2.395388e+02 6.486195e+02,2.605847e+02 6.516364e+02,2.697538e+02 C6.546532e+02,2.789229e+02 6.576700e+02,2.797141e+02 6.606869e+02,2.717471e+02 C6.637037e+02,2.637800e+02 6.667205e+02,2.440146e+02 6.697374e+02,2.219516e+02 C6.727542e+02,1.998886e+02 6.757710e+02,1.671090e+02 6.787879e+02,1.393692e+02 C6.818047e+02,1.116294e+02 6.848215e+02,7.834414e+01 6.878384e+02,5.551300e+01 C6.908552e+02,3.268185e+01 6.938721e+02,1.159253e+01 6.968889e+02,2.382294e+00 C6.999057e+02,-6.827941e+00 7.029226e+02,-7.673691e+00 7.059394e+02,2.515819e-01 C7.089562e+02,8.176855e+00 7.119731e+02,2.789741e+01 7.149899e+02,4.993393e+01 C7.180067e+02,7.197046e+01 7.210236e+02,1.047320e+02 7.240404e+02,1.324707e+02 C7.270572e+02,1.602094e+02 7.300741e+02,1.935103e+02 7.330909e+02,2.163662e+02 C7.361077e+02,2.392221e+02 7.391246e+02,2.603547e+02 7.421414e+02,2.696061e+02 C7.451582e+02,2.788574e+02 7.481751e+02,2.797577e+02 7.511919e+02,2.718742e+02 C7.542088e+02,2.639907e+02 7.572256e+02,2.443151e+02 7.602424e+02,2.223051e+02 C7.632593e+02,2.002951e+02 7.662761e+02,1.675517e+02 7.692929e+02,1.398141e+02 C7.723098e+02,1.120766e+02 7.753266e+02,7.876021e+01 7.783434e+02,5.587964e+01 C7.813603e+02,3.299906e+01 7.843771e+02,1.182312e+01 7.873939e+02,2.530698e+00 C7.904108e+02,-6.761721e+00 7.934276e+02,-7.716574e+00 7.964444e+02,1.251203e-01 C7.994613e+02,7.966814e+00 8.024781e+02,2.759742e+01 8.054949e+02,4.958086e+01 C8.085118e+02,7.156431e+01 8.115286e+02,1.042894e+02 8.145455e+02,1.320258e+02 C8.175623e+02,1.597622e+02 8.205791e+02,1.930939e+02 8.235960e+02,2.159991e+02 C8.266128e+02,2.389043e+02 8.296296e+02,2.601235e+02 8.326465e+02,2.694570e+02 C8.356633e+02,2.787905e+02 8.386801e+02,2.797999e+02 8.416970e+02,2.720000e+02 C8.447138e+02,2.642001e+02 8.477306e+02,2.446146e+02 8.507475e+02,2.226577e+02 C8.537643e+02,2.007009e+02 8.567811e+02,1.679942e+02 8.597980e+02,1.402591e+02 C8.628148e+02,1.125240e+02 8.658316e+02,7.917684e+01 8.688485e+02,5.624706e+01 C8.718653e+02,3.331729e+01 8.748822e+02,1.205493e+01 8.778990e+02,2.680419e+00 C8.809158e+02,-6.694092e+00 8.839327e+02,-7.758038e+00 8.869495e+02,0.000000e+00 C8.899663e+02,7.758038e+00 8.944916e+02,4.102387e+01 8.960000e+02,4.922865e+01 \"/></g><g fill=\"none\" stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect height=\"272\" vector-effect=\"non-scaling-stroke\" x=\"64\" y=\"64\" width=\"896\"/><g font-family=\"sans-serif\" text-anchor=\"middle\" dominant-baseline=\"middle\" fill=\"black\" font-size=\"18px\" font-style=\"normal\" font-weight=\"bold\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"512\" y=\"32\" dominant-baseline=\"middle\">Animated Sine</text></g></g></svg>"
       ]
      },
      "metadata": {},
@@ -675,7 +675,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 14,
    "id": "58248364-f1b3-4e56-adc7-7034a1f6c56d",
    "metadata": {},
    "outputs": [
@@ -895,7 +895,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 16,
    "id": "7298fde2-1bf2-4252-a07e-9601d1901b61",
    "metadata": {
     "tags": []
@@ -905,7 +905,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "2023/03/15 08:36:35 Goodbye!\n"
+      "2023/04/23 13:22:43 Goodbye!\n"
      ]
     }
    ],
@@ -950,7 +950,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 17,
    "id": "4e2e9992-3a74-4825-87d8-773bdc30b05f",
    "metadata": {
     "tags": []
@@ -986,7 +986,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 18,
    "id": "27c7aaad-b0d3-46f0-b1f6-dc66722fe5bd",
    "metadata": {
     "tags": []
@@ -1025,7 +1025,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 19,
    "id": "724e33f4-c5fa-4fbe-9d90-e411369a74f3",
    "metadata": {},
    "outputs": [
@@ -1033,12 +1033,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "go version go1.20 linux/amd64\n",
+      "go version go1.20.1 linux/amd64\n",
       "/home/janpf/Projects/gonb/examples\n",
-      "total 1000\n",
-      "-rw-rw-r-- 1 janpf janpf  86542 Feb 10 09:57 google_colab_demo.ipynb\n",
-      "-rwxr-xr-x 1 janpf janpf 774123 Feb  9 19:33 tutorial.html\n",
-      "-rw-r--r-- 1 janpf janpf 158122 Feb 12 10:46 tutorial.ipynb\n"
+      "total 296\n",
+      "-rw-r--r-- 1 janpf janpf 158378 Mar  8 07:18 experimental.ipynb\n",
+      "-rwxr-xr-x 1 janpf janpf  87160 Mar  5 15:26 google_colab_demo.ipynb\n",
+      "-rw-r--r-- 1 janpf janpf  28264 Apr 23 13:21 tutorial.ipynb\n"
      ]
     }
    ],
@@ -1062,7 +1062,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 20,
    "id": "be207993-219d-4a7f-a130-5111971fb867",
    "metadata": {},
    "outputs": [
@@ -1070,13 +1070,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/tmp/gonb_41aee2f3\n",
-      "total 10740\n",
-      "-rw-r--r-- 1 janpf janpf     1175 Feb 12 10:47 go.mod\n",
-      "-rwxr-xr-x 1 janpf janpf 10975084 Feb 12 10:47 gonb_41aee2f3\n",
-      "prw------- 1 janpf janpf        0 Feb 12 10:48 gonb_pipe_265383445\n",
-      "-rw-r--r-- 1 janpf janpf    10048 Feb 12 10:47 go.sum\n",
-      "-rw-r--r-- 1 janpf janpf      395 Feb 12 10:48 main.go\n"
+      "/tmp/gonb_f7c3f1d8\n",
+      "total 8948\n",
+      "-rw-r--r-- 1 janpf janpf    2779 Apr 23 13:22 go.mod\n",
+      "-rwxr-xr-x 1 janpf janpf 9069914 Apr 23 13:22 gonb_f7c3f1d8\n",
+      "prw------- 1 janpf janpf       0 Apr 23 13:22 gonb_pipe_4198142113\n",
+      "srwxr-xr-x 1 janpf janpf       0 Apr 23 13:21 gopls_socket\n",
+      "-rw-r--r-- 1 janpf janpf   74206 Apr 23 13:22 go.sum\n",
+      "-rw-r--r-- 1 janpf janpf    4603 Apr 23 13:22 main.go\n"
      ]
     }
    ],
@@ -1096,7 +1097,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "8688859a-ec3b-4e54-99b4-abbd8542091d",
    "metadata": {},
    "outputs": [
@@ -1145,7 +1146,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "3391f12e-131b-45b8-b270-6ba06abaac8c",
    "metadata": {},
    "outputs": [
@@ -1153,36 +1154,63 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "module gonb_41aee2f3\n",
+      "module gonb_f7c3f1d8\n",
       "\n",
       "go 1.20\n",
       "\n",
       "require (\n",
+      "\tfyne.io/fyne/v2 v2.3.3\n",
       "\tgithub.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b\n",
       "\tgithub.com/benc-uk/gofract v0.0.0-20230120162050-a6f644f92fd6\n",
       "\tgithub.com/erkkah/margaid v0.1.1-0.20230128143048-d60b2efd2f5a\n",
-      "\tgithub.com/janpfeifer/gonb v0.2.1\n",
-      "\tgithub.com/schollz/progressbar/v3 v3.13.0\n",
-      "\tgolang.org/x/exp v0.0.0-20230210204819-062eb4c674ab\n",
+      "\tgithub.com/janpfeifer/gonb v0.4.1\n",
+      "\tgithub.com/schollz/progressbar/v3 v3.13.1\n",
+      "\tgolang.org/x/exp v0.0.0-20230420155640-133eef4313cb\n",
       "\tgonum.org/v1/plot v0.12.0\n",
       ")\n",
       "\n",
       "require (\n",
+      "\tfyne.io/systray v1.10.1-0.20230312215936-7f71b037e260 // indirect\n",
       "\tgit.sr.ht/~sbinet/gg v0.3.1 // indirect\n",
+      "\tgithub.com/benoitkugler/textlayout v0.3.0 // indirect\n",
+      "\tgithub.com/davecgh/go-spew v1.1.1 // indirect\n",
+      "\tgithub.com/fredbi/uri v0.1.0 // indirect\n",
+      "\tgithub.com/fsnotify/fsnotify v1.5.4 // indirect\n",
+      "\tgithub.com/fyne-io/gl-js v0.0.0-20220119005834-d2da28d9ccfe // indirect\n",
+      "\tgithub.com/fyne-io/glfw-js v0.0.0-20220120001248-ee7290d23504 // indirect\n",
+      "\tgithub.com/fyne-io/image v0.0.0-20220602074514-4956b0afb3d2 // indirect\n",
       "\tgithub.com/go-fonts/liberation v0.2.0 // indirect\n",
+      "\tgithub.com/go-gl/gl v0.0.0-20211210172815-726fda9656d6 // indirect\n",
+      "\tgithub.com/go-gl/glfw/v3.3/glfw v0.0.0-20221017161538-93cebf72946b // indirect\n",
       "\tgithub.com/go-latex/latex v0.0.0-20210823091927-c0d11ff05a81 // indirect\n",
       "\tgithub.com/go-pdf/fpdf v0.6.0 // indirect\n",
+      "\tgithub.com/go-text/typesetting v0.0.0-20221212183139-1eb938670a1f // indirect\n",
+      "\tgithub.com/godbus/dbus/v5 v5.1.0 // indirect\n",
+      "\tgithub.com/gofrs/uuid v4.4.0+incompatible // indirect\n",
+      "\tgithub.com/goki/freetype v0.0.0-20220119013949-7a161fd3728c // indirect\n",
       "\tgithub.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0 // indirect\n",
+      "\tgithub.com/gopherjs/gopherjs v1.17.2 // indirect\n",
+      "\tgithub.com/jsummers/gobmp v0.0.0-20151104160322-e2ba15ffa76e // indirect\n",
       "\tgithub.com/lucasb-eyer/go-colorful v1.0.3 // indirect\n",
       "\tgithub.com/mattn/go-runewidth v0.0.14 // indirect\n",
       "\tgithub.com/mitchellh/colorstring v0.0.0-20190213212951-d06e56a500db // indirect\n",
       "\tgithub.com/pkg/errors v0.9.1 // indirect\n",
-      "\tgithub.com/rivo/uniseg v0.4.3 // indirect\n",
+      "\tgithub.com/pmezard/go-difflib v1.0.0 // indirect\n",
+      "\tgithub.com/rivo/uniseg v0.2.0 // indirect\n",
+      "\tgithub.com/srwiley/oksvg v0.0.0-20220731023508-a61f04f16b76 // indirect\n",
+      "\tgithub.com/srwiley/rasterx v0.0.0-20210519020934-456a8d69b780 // indirect\n",
+      "\tgithub.com/stretchr/testify v1.8.1 // indirect\n",
+      "\tgithub.com/tevino/abool v1.2.0 // indirect\n",
+      "\tgithub.com/yuin/goldmark v1.4.13 // indirect\n",
       "\tgolang.org/x/image v0.0.0-20220902085622-e7cb96979f69 // indirect\n",
-      "\tgolang.org/x/sys v0.4.0 // indirect\n",
-      "\tgolang.org/x/term v0.4.0 // indirect\n",
-      "\tgolang.org/x/text v0.3.7 // indirect\n",
-      "\tgopkg.in/yaml.v2 v2.3.0 // indirect\n",
+      "\tgolang.org/x/mobile v0.0.0-20211207041440-4e6c2922fdee // indirect\n",
+      "\tgolang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect\n",
+      "\tgolang.org/x/sys v0.6.0 // indirect\n",
+      "\tgolang.org/x/term v0.6.0 // indirect\n",
+      "\tgolang.org/x/text v0.6.0 // indirect\n",
+      "\tgopkg.in/yaml.v2 v2.4.0 // indirect\n",
+      "\tgopkg.in/yaml.v3 v3.0.1 // indirect\n",
+      "\thonnef.co/go/js/dom v0.0.0-20210725211120-f030747120f2 // indirect\n",
       ")\n",
       "\n",
       "replace github.com/janpfeifer/gonb => /home/janpf/Projects/gonb\n"
@@ -1214,9 +1242,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "ba9172b8-ede5-44cd-baa1-a58a1d668a98",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [
     {
      "name": "stdout",

--- a/goexec/README.md
+++ b/goexec/README.md
@@ -1,0 +1,14 @@
+## Package `goexec`
+
+The package `goexec` is responsible for executing the notebook cells using Go, as well as keeping the
+state of all current declarations (functions, variables, types, constants, imports) that once
+declared, stay alive for subsequent cell executions.
+
+The code is organized in the following files:
+
+* `goexec.go`: definition of the main `State` object and the various Go structs for the various declarations
+  (functions, variables, types, constants, imports), including the concept of cursor.
+* `execcode.go`: implements `State.ExecuteCell()`, the main functionality offered by the package.
+* `composer.go`: generate dynamically a `main.go` file from pre-parsed declarations. It includes some
+  the code that renders teh various types of declarations, and a writer that keep tabs on the cursor position.
+* `parser.go`: methods and objects used to parse the Go code from the cell, and again after `goimports` is run.

--- a/goexec/composer.go
+++ b/goexec/composer.go
@@ -2,16 +2,85 @@ package goexec
 
 import (
 	"fmt"
-	"github.com/janpfeifer/gonb/kernel"
 	"github.com/pkg/errors"
 	"io"
-	"log"
 	"os"
+	"sort"
 	"strings"
 )
 
-// This file holds the various functions used to compose the go sampleCellCode that
+// This file holds the various functions used to compose and render the go code that
 // will be compiled, from the parsed cells.
+
+// WriterWithCursor keep tabs of the current line/col of the file (presumably)
+// being written.
+type WriterWithCursor struct {
+	w         io.Writer
+	err       error // If err != nil, nothing is written anymore.
+	Line, Col int
+}
+
+// NewWriterWithCursor that keeps tabs of current line/col of the file (presumably)
+// being written.
+func NewWriterWithCursor(w io.Writer) *WriterWithCursor {
+	return &WriterWithCursor{w: w}
+}
+
+// Cursor returns the current position in the file, at the end of what has been written so far.
+func (w *WriterWithCursor) Cursor() Cursor {
+	return Cursor{Line: w.Line, Col: w.Col}
+}
+
+// CursorPlusDelta returns the expected cursor position in the current file, assuming the original cursor
+// is cursorDelta away from the current position in the file (stored in w).
+//
+// Semantically it's equivalent to `w.Cursor() + cursorDelta`.
+func (w *WriterWithCursor) CursorPlusDelta(delta Cursor) (fileCursor Cursor) {
+	fileCursor = w.Cursor()
+	fileCursor.Line += delta.Line
+	if delta.Line > 0 {
+		fileCursor.Col = delta.Col
+	} else {
+		fileCursor.Col += delta.Col
+	}
+	return fileCursor
+}
+
+// Error returns first error that happened during writing.
+func (w *WriterWithCursor) Error() error { return w.err }
+
+// Writef write with formatted text. Errors can be retrieved with Error.
+func (w *WriterWithCursor) Writef(format string, args ...any) {
+	if w.err != nil {
+		return
+	}
+	text := fmt.Sprintf(format, args...)
+	w.Write(text)
+}
+
+// Write writes the given content and keeps track of cursor. Errors can be retrieved with Error.
+func (w *WriterWithCursor) Write(content string) {
+	if w.err != nil {
+		return
+	}
+	var n int
+	n, w.err = w.w.Write([]byte(content))
+	if n != len(content) {
+		w.err = errors.Errorf("failed to write %q, %d bytes: wrote only %d", content, len(content), n)
+	}
+	if w.err != nil {
+		return
+	}
+
+	// Update cursor position.
+	parts := strings.Split(content, "\n")
+	if len(parts) == 1 {
+		w.Col += len(parts[0])
+	} else {
+		w.Line += len(parts) - 1
+		w.Col = len(parts[len(parts)-1])
+	}
+}
 
 func (s *State) writeLinesToFile(filePath string, lines <-chan string) (err error) {
 	var f *os.File
@@ -38,7 +107,203 @@ func (s *State) writeLinesToFile(filePath string, lines <-chan string) (err erro
 	return err
 }
 
-// createGoFileFromLines implements CreateMainGo with no extra functionality (like auto-import).
+// sortedKeys enumerate keys and sort them.
+func sortedKeys[T any](m map[string]T) (keys []string) {
+	keys = make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return
+}
+
+// RenderImports writes out `import ( ... )` for all imports in Declarations.
+func (d *Declarations) RenderImports(w *WriterWithCursor) (cursor Cursor) {
+	cursor = NoCursor
+	if len(d.Imports) == 0 {
+		return
+	}
+
+	w.Write("import (\n")
+	for _, key := range sortedKeys(d.Imports) {
+		importDecl := d.Imports[key]
+		w.Write("\t")
+		if importDecl.Alias != "" {
+			if importDecl.CursorInAlias {
+				cursor = w.CursorPlusDelta(importDecl.Cursor)
+			}
+			w.Writef("%s ", importDecl.Alias)
+		}
+		if importDecl.CursorInPath {
+			cursor = w.CursorPlusDelta(importDecl.Cursor)
+		}
+		w.Writef("%q\n", importDecl.Path)
+	}
+	w.Write(")\n\n")
+	return
+}
+
+// RenderVariables writes out `var ( ... )` for all variables in Declarations.
+func (d *Declarations) RenderVariables(w *WriterWithCursor) (cursor Cursor) {
+	cursor = NoCursor
+	if len(d.Variables) == 0 {
+		return
+	}
+
+	w.Write("var (\n")
+	for _, key := range sortedKeys(d.Variables) {
+		varDecl := d.Variables[key]
+		w.Write("\t")
+		if varDecl.CursorInName {
+			cursor = w.CursorPlusDelta(varDecl.Cursor)
+		}
+		w.Write(varDecl.Name)
+		if varDecl.TypeDefinition != "" {
+			w.Write(" ")
+			if varDecl.CursorInType {
+				cursor = w.CursorPlusDelta(varDecl.Cursor)
+			}
+			w.Write(varDecl.TypeDefinition)
+		}
+		if varDecl.ValueDefinition != "" {
+			w.Write(" = ")
+			if varDecl.CursorInValue {
+				cursor = w.CursorPlusDelta(varDecl.Cursor)
+			}
+			w.Write(varDecl.ValueDefinition)
+		}
+		w.Write("\n")
+	}
+	w.Write(")\n\n")
+	return
+}
+
+// RenderFunctions without comments, for all functions in Declarations.
+func (d *Declarations) RenderFunctions(w *WriterWithCursor) (cursor Cursor) {
+	cursor = NoCursor
+	if len(d.Functions) == 0 {
+		return
+	}
+
+	for _, key := range sortedKeys(d.Functions) {
+		funcDecl := d.Functions[key]
+		def := funcDecl.Definition
+		if funcDecl.HasCursor() {
+			cursor = w.CursorPlusDelta(funcDecl.Cursor)
+		}
+		if strings.HasPrefix(key, "init_") {
+			// TODO: this will not work if there is a comment before the function
+			//       which also has the string key. We need something more sophisticated.
+			def = strings.Replace(def, key, "init", 1)
+		}
+		w.Writef("%s\n\n", def)
+	}
+	return
+}
+
+// RenderTypes without comments.
+func (d *Declarations) RenderTypes(w *WriterWithCursor) (cursor Cursor) {
+	cursor = NoCursor
+	if len(d.Types) == 0 {
+		return
+	}
+
+	for _, key := range sortedKeys(d.Types) {
+		typeDecl := d.Types[key]
+		w.Write("type ")
+		if typeDecl.CursorInKey {
+			cursor = w.CursorPlusDelta(typeDecl.Cursor)
+		}
+		w.Writef("%s ", key)
+		if typeDecl.CursorInType {
+			cursor = w.CursorPlusDelta(typeDecl.Cursor)
+		}
+		w.Writef("%s\n", typeDecl.TypeDefinition)
+	}
+	w.Write("\n")
+	return
+}
+
+// RenderConstants without comments for all constants in Declarations.
+//
+// Constants are trickier to render because when they are defined in a block,
+// using `iota`, their ordering matters. So we re-render them in the same order
+// and blocks as they were originally parsed.
+//
+// The ordering is given by the sort order of the first element of each `const` block.
+func (d *Declarations) RenderConstants(w *WriterWithCursor) (cursor Cursor) {
+	cursor = NoCursor
+	if len(d.Constants) == 0 {
+		return
+	}
+
+	// Enumerate heads of const blocks.
+	headKeys := make([]string, 0, len(d.Constants))
+	for key, constDecl := range d.Constants {
+		if constDecl.Prev == nil {
+			// Head of the const block.
+			headKeys = append(headKeys, key)
+		}
+	}
+	sort.Strings(headKeys)
+
+	for _, headKey := range headKeys {
+		constDecl := d.Constants[headKey]
+		if constDecl.Next == nil {
+			// Render individual const declaration.
+			w.Write("const ")
+			constDecl.Render(w, &cursor)
+			w.Write("\n\n")
+			continue
+		}
+		// Render block of constants.
+		w.Write("const (\n")
+		for constDecl != nil {
+			w.Write("\t")
+			constDecl.Render(w, &cursor)
+			w.Write("\n")
+			constDecl = constDecl.Next
+		}
+		w.Write(")\n\n")
+	}
+	return
+}
+
+// Render Constant declaration (without the `const` keyword).
+func (c *Constant) Render(w *WriterWithCursor, cursor *Cursor) {
+	if c.CursorInKey {
+		*cursor = w.CursorPlusDelta(c.Cursor)
+	}
+	w.Write(c.Key)
+	if c.TypeDefinition != "" {
+		w.Write(" ")
+		if c.CursorInType {
+			*cursor = w.CursorPlusDelta(c.Cursor)
+		}
+		w.Write(c.TypeDefinition)
+	}
+	if c.ValueDefinition != "" {
+		w.Write(" = ")
+		if c.CursorInValue {
+			*cursor = w.CursorPlusDelta(c.Cursor)
+		}
+		w.Write(c.ValueDefinition)
+	}
+}
+
+// createGoFileFromLines creates a main.go file from the cell contents. It doesn't yet include previous declarations.
+//
+// Among the things it handles:
+// * Adding an initial `package main` line.
+// * Handle the special `%%` line, a shortcut to create a `func main()`.
+//
+// Parameters:
+// * filePath is the path where to write the Go code.
+// * lines are the lines in the cell.
+// * skipLines are lines in the cell that are not Go code: lines starting with "!" or "%" special characters.
+// * cursorInCell optionally specifies the cursor position in the cell. It can be set to NoCursor.
+//
+// It returns cursorInFile, the equivalent cursor position in the final file, considering the given cursorInCell.
 func (s *State) createGoFileFromLines(filePath string, lines []string, skipLines map[int]bool, cursorInCell Cursor) (cursorInFile Cursor, err error) {
 	linesChan := make(chan string, 1)
 
@@ -133,7 +398,7 @@ func (s *State) createMainFileFromDecls(decls *Declarations, mainDecl *Function)
 func (s *State) createMainContentsFromDecls(writer io.Writer, decls *Declarations, mainDecl *Function) (cursor Cursor, err error) {
 	cursor = NoCursor
 	w := NewWriterWithCursor(writer)
-	w.Format("package main\n\n")
+	w.Writef("package main\n\n")
 	if err != nil {
 		return
 	}
@@ -165,13 +430,13 @@ func (s *State) createMainContentsFromDecls(writer io.Writer, decls *Declaration
 	}
 
 	if mainDecl != nil {
-		w.Format("\n")
+		w.Writef("\n")
 		if mainDecl.HasCursor() {
 			cursor = mainDecl.Cursor
 			cursor.Line += w.Line
 			//log.Printf("Cursor in \"main\": %v", cursor)
 		}
-		w.Format("%s\n", mainDecl.Definition)
+		w.Writef("%s\n", mainDecl.Definition)
 	}
 	return
 }
@@ -180,91 +445,3 @@ var (
 	ParseError = fmt.Errorf("failed to parse cell contents")
 	CursorLost = fmt.Errorf("cursor position not rendered in main.go")
 )
-
-// parseLinesAndComposeMain parses the cell (given in lines and skipLines), merges with
-// currently memorized declarations (from previous Cell runs) and compose a `main.go`.
-//
-// On return the `main.go` file has been updated, and it returns the updated merged
-// declarations, the cursor position adjusted into the newly generate `main.go` file.
-//
-// If cursorInCell defines a cursor (it can be set to NoCursor), but the cursor position
-// is not rendered in the resulting `main.go`, a CursorLost error is returned.
-func (s *State) parseLinesAndComposeMain(msg kernel.Message, lines []string, skipLines map[int]bool, cursorInCell Cursor) (
-	updatedDecls *Declarations, cursorInFile Cursor, err error) {
-	if cursorInCell.HasCursor() {
-		log.Printf("Cursor in cell (%+v)", cursorInCell)
-	}
-	var cursorInTmpFile Cursor
-	cursorInTmpFile, err = s.createGoFileFromLines(s.MainPath(), lines, skipLines, cursorInCell)
-	if err != nil {
-		return nil, NoCursor, errors.WithMessagef(err, "in goexec.parseLinesAndComposeMain()")
-	}
-	newDecls := NewDeclarations()
-	if err = s.ParseFromMainGo(msg, cursorInTmpFile, newDecls); err != nil {
-		// If cell is in an un-parseable state, just returns empty context. User can try to
-		// run cell to get an error.
-		return nil, NoCursor, errors.WithStack(ParseError)
-	}
-
-	// Checks whether there is a "main" function defined in the sampleCellCode.
-	mainDecl, hasMain := newDecls.Functions["main"]
-	if hasMain {
-		// Remove "main" from newDecls: this should not be stored from one cell execution from
-		// another.
-		delete(newDecls.Functions, "main")
-	} else {
-		// Declare a stub main function, just so we can try to compile the final sampleCellCode.
-		mainDecl = &Function{Key: "main", Name: "main", Definition: "func main() { flag.Parse() }"}
-	}
-	_ = mainDecl
-
-	// Merge cell declarations with a copy of the current state: we don't want to commit the new
-	// declarations until they compile successfully.
-	updatedDecls = s.Decls.Copy()
-	updatedDecls.ClearCursor()
-	updatedDecls.MergeFrom(newDecls)
-
-	// Render declarations to main.go.
-	cursorInFile, err = s.createMainFileFromDecls(updatedDecls, mainDecl)
-	if err != nil {
-		return nil, NoCursor, errors.WithMessagef(err, "in goexec.InspectIdentifierInCell() while generating main.go with all declarations")
-	}
-	if cursorInCell.HasCursor() && !cursorInFile.HasCursor() {
-		// Returns empty data, which returns a "not found".
-		return nil, NoCursor, errors.WithStack(CursorLost)
-	}
-	if cursorInCell.HasCursor() {
-		s.logCursor(cursorInFile)
-	}
-	return updatedDecls, cursorInFile, nil
-}
-
-const cursorStr = "‸"
-
-// logCursor will log the line in `main.go` the cursor is pointing to, and puts a
-// "*" where the
-func (s *State) logCursor(cursor Cursor) {
-	content, err := s.readMainGo()
-	if err != nil {
-		log.Printf("Failed to read main.go, for debugging.")
-	} else {
-		log.Printf("Cursor in main.go (%+v): %s", cursor, lineWithCursor(content, cursor))
-	}
-}
-
-func lineWithCursor(content string, cursor Cursor) string {
-	if !cursor.HasCursor() {
-		return "cursor position non-existent"
-	}
-	var modLine string
-	lines := strings.Split(content, "\n")
-	if cursor.Line < len(lines) {
-		line := lines[cursor.Line]
-		if cursor.Col < len(line) {
-			modLine = line[:cursor.Col] + cursorStr + line[cursor.Col:]
-		} else {
-			modLine = line + cursorStr
-		}
-	}
-	return modLine
-}

--- a/goexec/composer.go
+++ b/goexec/composer.go
@@ -2,6 +2,7 @@ package goexec
 
 import (
 	"fmt"
+	. "github.com/janpfeifer/gonb/common"
 	"github.com/pkg/errors"
 	"io"
 	"os"
@@ -304,7 +305,7 @@ func (c *Constant) Render(w *WriterWithCursor, cursor *Cursor) {
 // * cursorInCell optionally specifies the cursor position in the cell. It can be set to NoCursor.
 //
 // It returns cursorInFile, the equivalent cursor position in the final file, considering the given cursorInCell.
-func (s *State) createGoFileFromLines(filePath string, lines []string, skipLines map[int]struct{}, cursorInCell Cursor) (cursorInFile Cursor, err error) {
+func (s *State) createGoFileFromLines(filePath string, lines []string, skipLines Set[int], cursorInCell Cursor) (cursorInFile Cursor, err error) {
 	cursorInFile = NoCursor
 
 	var f *os.File

--- a/goexec/composer.go
+++ b/goexec/composer.go
@@ -301,7 +301,7 @@ func (s *State) createGoFileFromLines(filePath string, lines []string, skipLines
 	var createdFuncMain bool
 	for ii, line := range lines {
 		if strings.HasPrefix(line, "%main") || strings.HasPrefix(line, "%%") {
-			w.Write("func main() {\n\tflag.Parse\n")
+			w.Write("func main() {\n\tflag.Parse()\n")
 			createdFuncMain = true
 			continue
 		}

--- a/goexec/composer_test.go
+++ b/goexec/composer_test.go
@@ -1,0 +1,57 @@
+package goexec
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/require"
+	"os"
+	"strings"
+	"testing"
+)
+
+// The tests here uses the sample code and utility functions defined in `parser_test.go`.
+
+var sampleCellContentSuffix = `
+!echo nonono
+
+%%
+fmt.Printf("Hello! %s\n", c)
+fmt.Printf("1 + 3 = %d\n", sum(1, 3))
+fmt.Printf("math.Pi - PI=%f\n", math.Pi - float64(PI32))
+`
+
+func TestCreateGoFileFromLines(t *testing.T) {
+	// Test cursor positioning in generated lines.
+	s := newEmptyState(t)
+	//defer func() {
+	//	err := s.Finalize()
+	//	require.NoError(t, err, "Failed to finalized state")
+	//}()
+	fmt.Println(s.MainPath())
+
+	content := sampleCellCode + sampleCellContentSuffix
+	lines := strings.Split(content, "\n")
+	skipLines := make(map[int]struct{})
+	for ii, line := range lines {
+		if line == "!echo nonono" {
+			skipLines[ii] = struct{}{}
+		}
+	}
+
+	cursorInCell := Cursor{38, 27} // "func (k *Kg) Gain(lasagna K_g) {"
+	cursorLine := lines[cursorInCell.Line]
+	cursorInFile, err := s.createGoFileFromLines(s.MainPath(), lines, skipLines, cursorInCell)
+	require.NoErrorf(t, err, "Failed createGoFileFromLines(%q)", s.MainPath())
+
+	// Read generated contents:
+	contentBytes, err := os.ReadFile(s.MainPath())
+	require.NoErrorf(t, err, "Failed os.ReadFile(%q)", s.MainPath())
+	content = string(contentBytes)
+	require.Contains(t, content, "func main() {")
+	require.NotContains(t, content, "echo nonono", "Line should have been filtered out, since it is in skipLine.")
+
+	originalNumLines := len(lines)
+	newLines := strings.Split(content, "\n")
+	newNumLines := len(newLines)
+	require.Equal(t, originalNumLines+5, newNumLines, "Number of lines of generated main.go")
+	require.Equal(t, cursorLine, newLines[cursorInFile.Line], "Cursor line remains the same.")
+}

--- a/goexec/composer_test.go
+++ b/goexec/composer_test.go
@@ -40,7 +40,7 @@ func TestCreateGoFileFromLines(t *testing.T) {
 
 	cursorInCell := Cursor{38, 27} // "func (k *Kg) Gain(lasagna K_g) {"
 	cursorLine := lines[cursorInCell.Line]
-	cursorInFile, err := s.createGoFileFromLines(s.MainPath(), lines, skipLines, cursorInCell)
+	cursorInFile, fileToCellMap, err := s.createGoFileFromLines(s.MainPath(), lines, skipLines, cursorInCell)
 	require.NoErrorf(t, err, "Failed createGoFileFromLines(%q)", s.MainPath())
 
 	// Read generated contents:
@@ -55,4 +55,16 @@ func TestCreateGoFileFromLines(t *testing.T) {
 	newNumLines := len(newLines)
 	require.Equal(t, originalNumLines+5, newNumLines, "Number of lines of generated main.go")
 	require.Equal(t, cursorLine, newLines[cursorInFile.Line], "Cursor line remains the same.")
+
+	for ii, newLine := range newLines {
+		if ii >= newNumLines-8 {
+			// Content of lines change (an indentation is added) so we skip these.
+			break
+		}
+		originalLineIdx := fileToCellMap[ii]
+		if originalLineIdx == NoCursorLine {
+			continue
+		}
+		require.Equalf(t, lines[originalLineIdx], newLine, "Line mapping look wrong: file line %d --> cell line %d", ii, originalLineIdx)
+	}
 }

--- a/goexec/composer_test.go
+++ b/goexec/composer_test.go
@@ -2,6 +2,7 @@ package goexec
 
 import (
 	"fmt"
+	. "github.com/janpfeifer/gonb/common"
 	"github.com/stretchr/testify/require"
 	"os"
 	"strings"
@@ -30,10 +31,10 @@ func TestCreateGoFileFromLines(t *testing.T) {
 
 	content := sampleCellCode + sampleCellContentSuffix
 	lines := strings.Split(content, "\n")
-	skipLines := make(map[int]struct{})
+	skipLines := MakeSet[int]()
 	for ii, line := range lines {
 		if line == "!echo nonono" {
-			skipLines[ii] = struct{}{}
+			skipLines.Insert(ii)
 		}
 	}
 

--- a/goexec/composer_test.go
+++ b/goexec/composer_test.go
@@ -11,25 +11,16 @@ import (
 
 // The tests here uses the sample code and utility functions defined in `parser_test.go`.
 
-var sampleCellContentSuffix = `
-!echo nonono
-
-%%
-fmt.Printf("Hello! %s\n", c)
-fmt.Printf("1 + 3 = %d\n", sum(1, 3))
-fmt.Printf("math.Pi - PI=%f\n", math.Pi - float64(PI32))
-`
-
 func TestCreateGoFileFromLines(t *testing.T) {
 	// Test cursor positioning in generated lines.
 	s := newEmptyState(t)
-	//defer func() {
-	//	err := s.Finalize()
-	//	require.NoError(t, err, "Failed to finalized state")
-	//}()
+	defer func() {
+		err := s.Finalize()
+		require.NoError(t, err, "Failed to finalized state")
+	}()
 	fmt.Println(s.MainPath())
 
-	content := sampleCellCode + sampleCellContentSuffix
+	content := sampleCellCode
 	lines := strings.Split(content, "\n")
 	skipLines := MakeSet[int]()
 	for ii, line := range lines {

--- a/goexec/errorcontext.go
+++ b/goexec/errorcontext.go
@@ -26,6 +26,9 @@ type errorLine struct {
 	Message    string // Error message, what comes after the `file:line_number:col_number`
 	Location   string // `file:line_number:col_number` prefix, only if HasContext == true.
 	Context    string // Context to display on a mouse-over window, only if HasContext == true.
+
+	HasCellInfo bool
+	CellInfo    string
 }
 
 // To check the standard Jupyter colors to choose from, see:
@@ -64,15 +67,28 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 	border-color: var(--jp-border-color2);
 	font-weight: bold;
 }
+.gonb-cell-line-info {
+	background: var(--jp-layout-color2);
+	color: #999;
+	margin: 0.1em;
+	border: 1px solid var(--jp-border-color1);
+	padding-left: 0.2em;
+	padding-right: 0.2em;
+}
 </style>
 <div class="lm-Widget p-Widget lm-Panel p-Panel jp-OutputArea-child">
 <div class="lm-Widget p-Widget jp-RenderedText jp-mod-trusted jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" style="font-family: monospace;">
 {{range .Lines}}
 {{if .HasContext}}
+{{if .HasCellInfo}}
+<span class="gonb-cell-line-info">{{.CellInfo}}</span>
+{{end}}
 <span class="gonb-error-location">{{.Location}}</span> {{.Message}}
-<div class="gonb-error-context">{{.Context}}</div>
+<div class="gonb-error-context">
+{{.Context}}
+</div>
 {{else}}
-<pre>{{.Message}}</pre>
+<pre>{{.Location}} {{.Message}}</pre>
 {{end}}
 <br/>
 {{end}}
@@ -87,7 +103,7 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 //
 // Any errors within here are logged and simply ignored, since this is already
 // used to report errors
-func (s *State) DisplayErrorWithContext(msg kernel.Message, errorMsg string) {
+func (s *State) DisplayErrorWithContext(msg kernel.Message, fileToCellIdAndLine []CellIdAndLine, errorMsg string) {
 	// Default report, and makes sure display is called at the end.
 	reportHTML := "<pre>" + errorMsg + "</pre>" // If anything goes wrong, simply display the error message.
 	defer func() {
@@ -110,7 +126,7 @@ func (s *State) DisplayErrorWithContext(msg kernel.Message, errorMsg string) {
 	lines := strings.Split(errorMsg, "\n")
 	report := &errorReport{Lines: make([]errorLine, len(lines))}
 	for ii, line := range lines {
-		report.Lines[ii] = s.parseErrorLine(line, codeLines)
+		report.Lines[ii] = s.parseErrorLine(line, codeLines, fileToCellIdAndLine)
 	}
 
 	// Render error block.
@@ -145,7 +161,7 @@ func inBetween[T constraints.Ordered](x, from, to T) T {
 	return min(max(x, from), to)
 }
 
-func (s *State) parseErrorLine(lineStr string, codeLines []string) (l errorLine) {
+func (s *State) parseErrorLine(lineStr string, codeLines []string, fileToCellIdAndLine []CellIdAndLine) (l errorLine) {
 	l.HasContext = false
 	matches := reFileLinePrefix.FindStringSubmatch(lineStr)
 	if len(codeLines) == 0 || len(matches) != 5 {
@@ -175,6 +191,18 @@ func (s *State) parseErrorLine(lineStr string, codeLines []string) (l errorLine)
 		parts = append(parts, part)
 	}
 	l.Context = strings.Join(parts, "")
+
+	// Gather CellInfo
+	if lineNum > 0 && lineNum < len(fileToCellIdAndLine) && fileToCellIdAndLine[lineNum].Line != NoCursorLine {
+		cell := fileToCellIdAndLine[lineNum]
+		l.HasCellInfo = true
+		// Notice GoNB store lines starting at 0, but Jupyter display lines starting at 1, so we add 1 here.
+		if cell.Id != -1 {
+			l.CellInfo = fmt.Sprintf("Cell[%d]: Line %d", cell.Id, cell.Line+1)
+		} else {
+			l.CellInfo = fmt.Sprintf("Cell Line %d", cell.Line+1)
+		}
+	}
 	return
 }
 

--- a/goexec/errorcontext.go
+++ b/goexec/errorcontext.go
@@ -79,6 +79,7 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 </div>
 `))
 
+// Example type of error message:
 // /tmp/gonb_4e5ea2e7/main.go:3:1: expected declaration, found fmt
 
 // DisplayErrorWithContext in an HTML div, with a mouse-over pop-up window

--- a/goexec/errorcontext.go
+++ b/goexec/errorcontext.go
@@ -86,8 +86,9 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 {{.Context}}
 </div>
 {{else}}
-<span style="white-space: pre;">{{.Location}} {{.Message}}</span><br/>
+<span style="white-space: pre;">{{.Location}} {{.Message}}</span>
 {{end}}
+<br/>
 {{end}}
 </div>
 `))

--- a/goexec/errorcontext.go
+++ b/goexec/errorcontext.go
@@ -65,6 +65,7 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 	border-style: dotted;
 	border-width: 1px;	
 	border-color: var(--jp-border-color2);
+	background-color: var(--jp-rendermime-error-background);
 	font-weight: bold;
 }
 .gonb-cell-line-info {
@@ -79,18 +80,14 @@ var templateErrorReport = template.Must(template.New("error_report").Parse(`
 <div class="lm-Widget p-Widget lm-Panel p-Panel jp-OutputArea-child">
 <div class="lm-Widget p-Widget jp-RenderedText jp-mod-trusted jp-OutputArea-output" data-mime-type="application/vnd.jupyter.stderr" style="font-family: monospace;">
 {{range .Lines}}
-{{if .HasContext}}
-{{if .HasCellInfo}}
-<span class="gonb-cell-line-info">{{.CellInfo}}</span>
-{{end}}
-<span class="gonb-error-location">{{.Location}}</span> {{.Message}}
+{{if .HasContext}}{{if .HasCellInfo}}<span class="gonb-cell-line-info">{{.CellInfo}}</span>
+{{end}}<span class="gonb-error-location">{{.Location}}</span> {{.Message}}
 <div class="gonb-error-context">
 {{.Context}}
 </div>
 {{else}}
-<pre>{{.Location}} {{.Message}}</pre>
+<span style="white-space: pre;">{{.Location}} {{.Message}}</span><br/>
 {{end}}
-<br/>
 {{end}}
 </div>
 `))

--- a/goexec/execcode.go
+++ b/goexec/execcode.go
@@ -8,15 +8,18 @@ import (
 )
 
 // ExecuteCell takes the contents of a cell, parses it, merges new declarations with the ones
-// from previous definitions, render a final main.go sampleCellCode with the whole content,
+// from previous definitions, render a final main.go code with the whole content,
 // compiles and runs it.
+//
+// skipLines are lines that should not be considered as Go code. Typically, these are the special
+// commands (like `%%`, `%args`, `%reset`, or bash lines starting with `!`).
 func (s *State) ExecuteCell(msg kernel.Message, lines []string, skipLines map[int]bool) error {
 	updatedDecls, _, err := s.parseLinesAndComposeMain(msg, lines, skipLines, NoCursor)
 	if err != nil {
 		return errors.WithMessagef(err, "in goexec.ExecuteCell()")
 	}
 
-	// Run `goimports` (or the sampleCellCode that implements it)
+	// Run `goimports` (or the code that implements it)
 	if err = s.GoImports(msg); err != nil {
 		return errors.WithMessagef(err, "goimports failed")
 	}
@@ -29,7 +32,7 @@ func (s *State) ExecuteCell(msg kernel.Message, lines []string, skipLines map[in
 	// Compilation successful: save merged declarations into current State.
 	s.Decls = updatedDecls
 
-	// Execute compiled sampleCellCode.
+	// Execute compiled code.
 	return s.Execute(msg)
 }
 

--- a/goexec/execcode.go
+++ b/goexec/execcode.go
@@ -35,7 +35,7 @@ func (s *State) ExecuteCell(msg kernel.Message, cellId int, lines []string, skip
 	s.Decls = updatedDecls
 
 	// Execute compiled code.
-	return s.Execute(msg)
+	return s.Execute(msg, fileToCellIdAndLine)
 }
 
 func (s *State) BinaryPath() string {
@@ -46,8 +46,8 @@ func (s *State) MainPath() string {
 	return path.Join(s.TempDir, "main.go")
 }
 
-func (s *State) Execute(msg kernel.Message) error {
-	return kernel.PipeExecToJupyter(msg, "", s.BinaryPath(), s.Args...)
+func (s *State) Execute(msg kernel.Message, fileToCellIdAndLine []CellIdAndLine) error {
+	return kernel.PipeExecToJupyter(msg, s.BinaryPath(), s.Args...).Run()
 }
 
 // Compile compiles the currently generate go files in State.TempDir to a binary named State.Package.
@@ -108,7 +108,7 @@ can install it from the notebook with:
 	}
 
 	// Download missing dependencies.
-	if s.AutoGet {
+	if !s.AutoGet {
 		return fileToCellIdAndLine, nil
 	}
 	cmd = exec.Command("go", "get")

--- a/goexec/execcode.go
+++ b/goexec/execcode.go
@@ -15,7 +15,7 @@ import (
 // skipLines are lines that should not be considered as Go code. Typically, these are the special
 // commands (like `%%`, `%args`, `%reset`, or bash lines starting with `!`).
 func (s *State) ExecuteCell(msg kernel.Message, cellId int, lines []string, skipLines Set[int]) error {
-	updatedDecls, _, err := s.parseLinesAndComposeMain(msg, lines, skipLines, NoCursor)
+	updatedDecls, _, err := s.parseLinesAndComposeMain(msg, cellId, lines, skipLines, NoCursor)
 	if err != nil {
 		return errors.WithMessagef(err, "in goexec.ExecuteCell()")
 	}

--- a/goexec/execcode.go
+++ b/goexec/execcode.go
@@ -13,7 +13,7 @@ import (
 //
 // skipLines are lines that should not be considered as Go code. Typically, these are the special
 // commands (like `%%`, `%args`, `%reset`, or bash lines starting with `!`).
-func (s *State) ExecuteCell(msg kernel.Message, lines []string, skipLines map[int]bool) error {
+func (s *State) ExecuteCell(msg kernel.Message, lines []string, skipLines map[int]struct{}) error {
 	updatedDecls, _, err := s.parseLinesAndComposeMain(msg, lines, skipLines, NoCursor)
 	if err != nil {
 		return errors.WithMessagef(err, "in goexec.ExecuteCell()")

--- a/goexec/execcode.go
+++ b/goexec/execcode.go
@@ -1,6 +1,7 @@
 package goexec
 
 import (
+	. "github.com/janpfeifer/gonb/common"
 	"github.com/janpfeifer/gonb/kernel"
 	"github.com/pkg/errors"
 	"os/exec"
@@ -13,7 +14,7 @@ import (
 //
 // skipLines are lines that should not be considered as Go code. Typically, these are the special
 // commands (like `%%`, `%args`, `%reset`, or bash lines starting with `!`).
-func (s *State) ExecuteCell(msg kernel.Message, lines []string, skipLines map[int]struct{}) error {
+func (s *State) ExecuteCell(msg kernel.Message, cellId int, lines []string, skipLines Set[int]) error {
 	updatedDecls, _, err := s.parseLinesAndComposeMain(msg, lines, skipLines, NoCursor)
 	if err != nil {
 		return errors.WithMessagef(err, "in goexec.ExecuteCell()")

--- a/goexec/goexec.go
+++ b/goexec/goexec.go
@@ -1,4 +1,4 @@
-// Package goexec executes cells with Go sampleCellCode for the gonb kernel.
+// Package goexec executes cells with Go code for the gonb kernel.
 //
 // It defines a State object, that carries all the globals defined so far. It provides
 // the ExecuteCell method, to run a new cell.
@@ -24,7 +24,7 @@ type State struct {
 	// Temporary directory where Go program is build at each execution.
 	UniqueID, Package, TempDir string
 
-	// Building and executing go sampleCellCode configuration:
+	// Building and executing go code configuration:
 	Args    []string // Args to be passed to the program, after being executed.
 	AutoGet bool     // Whether to do a "go get" before compiling, to fetch missing external modules.
 
@@ -86,7 +86,7 @@ func New(uniqueID string) (*State, error) {
 
 	} else {
 		msg := `
-Program gopls is not installed. It is used to inspect into sampleCellCode
+Program gopls is not installed. It is used to inspect into code
 and provide contextual information and autocompletion. It is a 
 standard Go toolkit package. You can install it from the notebook
 with:

--- a/goexec/goexec.go
+++ b/goexec/goexec.go
@@ -224,6 +224,15 @@ type CellLines struct {
 	Lines []int
 }
 
+// Append id and line numbers to fileToCellIdAndLine, a slice of `CellIdAndLine`. This is used when
+// rendering a declaration to a file.
+func (c CellLines) Append(fileToCellIdAndLine []CellIdAndLine) []CellIdAndLine {
+	for _, lineNum := range c.Lines {
+		fileToCellIdAndLine = append(fileToCellIdAndLine, CellIdAndLine{Id: c.Id, Line: lineNum})
+	}
+	return fileToCellIdAndLine
+}
+
 // Function definition.
 type Function struct {
 	Cursor

--- a/goexec/goexec.go
+++ b/goexec/goexec.go
@@ -60,7 +60,7 @@ func New(uniqueID string) (*State, error) {
 		return nil, errors.Wrapf(err, "failed to create temporary directory %q", s.TempDir)
 	}
 
-	// Run go mod init on given directory.
+	// Exec go mod init on given directory.
 	cmd := exec.Command("go", "mod", "init", s.Package)
 	cmd.Dir = s.TempDir
 	var output []byte

--- a/goexec/goexec.go
+++ b/goexec/goexec.go
@@ -101,6 +101,22 @@ with:
 	return s, nil
 }
 
+// Finalize stops gopls and removes temporary files and directories.
+func (s *State) Finalize() error {
+	if s.gopls != nil {
+		s.gopls.Shutdown()
+		s.gopls = nil
+	}
+	if s.TempDir != "" {
+		err := os.RemoveAll(s.TempDir)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to remove goexec.State temporary directory %s", s.TempDir)
+		}
+		s.TempDir = "/"
+	}
+	return nil
+}
+
 func NewDeclarations() *Declarations {
 	return &Declarations{
 		Imports:   make(map[string]*Import),

--- a/goexec/goplsclient/conn.go
+++ b/goexec/goplsclient/conn.go
@@ -85,7 +85,7 @@ func (c *Client) Connect(ctx context.Context) error {
 	c.jsonHandler = &jsonrpc2Handler{client: c}
 	c.jsonConn.AddHandler(c.jsonHandler)
 	go func(currentConn net.Conn) {
-		// Run should use a non-expiring context.
+		// Exec should use a non-expiring context.
 		ctx := context.Background()
 		_ = c.jsonConn.Run(ctx)
 		log.Printf("- gopls connection stopped")

--- a/goexec/inspect.go
+++ b/goexec/inspect.go
@@ -27,7 +27,7 @@ func (s *State) InspectIdentifierInCell(lines []string, skipLines map[int]struct
 	// Generate `main.go` with contents of current cell.
 	cursorInCell := Cursor{cursorLine, cursorCol}
 	cellId := -1 // Inspect doesn't actually execute it, so parsed contents of cell are not kept.
-	_, cursorInFile, err := s.parseLinesAndComposeMain(nil, cellId, lines, skipLines, cursorInCell)
+	_, _, cursorInFile, _, err := s.parseLinesAndComposeMain(nil, cellId, lines, skipLines, cursorInCell)
 	if err != nil {
 		if errors.Is(err, ParseError) || errors.Is(err, CursorLost) {
 			return make(kernel.MIMEMap), nil
@@ -71,7 +71,7 @@ func (s *State) AutoCompleteOptionsInCell(cellLines []string, skipLines map[int]
 	cursorInCell := Cursor{cursorLine, cursorCol}
 	var cursorInFile Cursor
 	cellId := -1 // AutoComplete doesn't actually execute it, so parsed contents of cell are not kept.
-	_, cursorInFile, err = s.parseLinesAndComposeMain(nil, cellId, cellLines, skipLines, cursorInCell)
+	_, _, cursorInFile, _, err = s.parseLinesAndComposeMain(nil, cellId, cellLines, skipLines, cursorInCell)
 	if err != nil {
 		if errors.Is(err, ParseError) || errors.Is(err, CursorLost) {
 			// Simply return no auto-complete.

--- a/goexec/inspect.go
+++ b/goexec/inspect.go
@@ -14,12 +14,12 @@ import (
 
 // InspectIdentifierInCell implements an `inspect_request` from Jupyter, using `gopls`.
 // It updates `main.go` with the cell contents (given as lines)
-func (s *State) InspectIdentifierInCell(lines []string, skipLines map[int]bool, cursorLine, cursorCol int) (kernel.MIMEMap, error) {
+func (s *State) InspectIdentifierInCell(lines []string, skipLines map[int]struct{}, cursorLine, cursorCol int) (kernel.MIMEMap, error) {
 	if s.gopls == nil {
 		// gopls not installed.
 		return make(kernel.MIMEMap), nil
 	}
-	if skipLines[cursorLine] {
+	if _, found := skipLines[cursorLine]; found {
 		// Only Go code can be inspected here.
 		return nil, errors.Errorf("goexec.InspectIdentifierInCell() can only inspect Go code, line %d is a secial command line: %q", cursorLine, lines[cursorLine])
 	}
@@ -54,13 +54,13 @@ func (s *State) InspectIdentifierInCell(lines []string, skipLines map[int]bool, 
 
 // AutoCompleteOptionsInCell implements an `complete_request` from Jupyter, using `gopls`.
 // It updates `main.go` with the cell contents (given as lines)
-func (s *State) AutoCompleteOptionsInCell(cellLines []string, skipLines map[int]bool,
+func (s *State) AutoCompleteOptionsInCell(cellLines []string, skipLines map[int]struct{},
 	cursorLine, cursorCol int, reply *kernel.CompleteReply) (err error) {
 	if s.gopls == nil {
 		// gopls not installed.
 		return
 	}
-	if skipLines[cursorLine] {
+	if _, found := skipLines[cursorLine]; found {
 		// Only Go code can be inspected here.
 		err = errors.Errorf("goexec.AutoCompleteOptionsInCell() can only auto-complete Go code, line %d is a secial command line: %q", cursorLine, cellLines[cursorLine])
 		return

--- a/goexec/inspect.go
+++ b/goexec/inspect.go
@@ -26,7 +26,8 @@ func (s *State) InspectIdentifierInCell(lines []string, skipLines map[int]struct
 
 	// Generate `main.go` with contents of current cell.
 	cursorInCell := Cursor{cursorLine, cursorCol}
-	_, cursorInFile, err := s.parseLinesAndComposeMain(nil, lines, skipLines, cursorInCell)
+	cellId := -1 // Inspect doesn't actually execute it, so parsed contents of cell are not kept.
+	_, cursorInFile, err := s.parseLinesAndComposeMain(nil, cellId, lines, skipLines, cursorInCell)
 	if err != nil {
 		if errors.Is(err, ParseError) || errors.Is(err, CursorLost) {
 			return make(kernel.MIMEMap), nil
@@ -69,7 +70,8 @@ func (s *State) AutoCompleteOptionsInCell(cellLines []string, skipLines map[int]
 	// Generate `main.go` with contents of current cell.
 	cursorInCell := Cursor{cursorLine, cursorCol}
 	var cursorInFile Cursor
-	_, cursorInFile, err = s.parseLinesAndComposeMain(nil, cellLines, skipLines, cursorInCell)
+	cellId := -1 // AutoComplete doesn't actually execute it, so parsed contents of cell are not kept.
+	_, cursorInFile, err = s.parseLinesAndComposeMain(nil, cellId, cellLines, skipLines, cursorInCell)
 	if err != nil {
 		if errors.Is(err, ParseError) || errors.Is(err, CursorLost) {
 			// Simply return no auto-complete.

--- a/goexec/inspect.go
+++ b/goexec/inspect.go
@@ -20,8 +20,8 @@ func (s *State) InspectIdentifierInCell(lines []string, skipLines map[int]bool, 
 		return make(kernel.MIMEMap), nil
 	}
 	if skipLines[cursorLine] {
-		// Only Go sampleCellCode can be inspected here.
-		return nil, errors.Errorf("goexec.InspectIdentifierInCell() can only inspect Go sampleCellCode, line %d is a secial command line: %q", cursorLine, lines[cursorLine])
+		// Only Go code can be inspected here.
+		return nil, errors.Errorf("goexec.InspectIdentifierInCell() can only inspect Go code, line %d is a secial command line: %q", cursorLine, lines[cursorLine])
 	}
 
 	// Generate `main.go` with contents of current cell.
@@ -61,8 +61,8 @@ func (s *State) AutoCompleteOptionsInCell(cellLines []string, skipLines map[int]
 		return
 	}
 	if skipLines[cursorLine] {
-		// Only Go sampleCellCode can be inspected here.
-		err = errors.Errorf("goexec.AutoCompleteOptionsInCell() can only auto-complete Go sampleCellCode, line %d is a secial command line: %q", cursorLine, cellLines[cursorLine])
+		// Only Go code can be inspected here.
+		err = errors.Errorf("goexec.AutoCompleteOptionsInCell() can only auto-complete Go code, line %d is a secial command line: %q", cursorLine, cellLines[cursorLine])
 		return
 	}
 

--- a/goexec/parser.go
+++ b/goexec/parser.go
@@ -323,7 +323,7 @@ func (s *State) parseLinesAndComposeMain(msg kernel.Message, lines []string, ski
 		log.Printf("Cursor in cell (%+v)", cursorInCell)
 	}
 	var cursorInTmpFile Cursor
-	cursorInTmpFile, err = s.createGoFileFromLines(s.MainPath(), lines, skipLines, cursorInCell)
+	cursorInTmpFile, _, err = s.createGoFileFromLines(s.MainPath(), lines, skipLines, cursorInCell)
 	if err != nil {
 		return nil, NoCursor, errors.WithMessagef(err, "in goexec.parseLinesAndComposeMain()")
 	}

--- a/goexec/parser.go
+++ b/goexec/parser.go
@@ -2,6 +2,7 @@ package goexec
 
 import (
 	"fmt"
+	. "github.com/janpfeifer/gonb/common"
 	"github.com/janpfeifer/gonb/kernel"
 	"github.com/pkg/errors"
 	"go/ast"
@@ -316,7 +317,7 @@ func (pi *parseInfo) ParseTypeEntry(decls *Declarations, typedDecl *ast.GenDecl)
 //
 // skipLines are lines that should not be considered as Go code. Typically, these are the special
 // commands (like `%%`, `%args`, `%reset`, or bash lines starting with `!`).
-func (s *State) parseLinesAndComposeMain(msg kernel.Message, lines []string, skipLines map[int]struct{}, cursorInCell Cursor) (
+func (s *State) parseLinesAndComposeMain(msg kernel.Message, lines []string, skipLines Set[int], cursorInCell Cursor) (
 	updatedDecls *Declarations, cursorInFile Cursor, err error) {
 	if cursorInCell.HasCursor() {
 		log.Printf("Cursor in cell (%+v)", cursorInCell)

--- a/goexec/parser_test.go
+++ b/goexec/parser_test.go
@@ -104,6 +104,10 @@ func sum[T interface{int | float32 | float64}](a, b T) T {
 func init_c() {
 	c += ", blah"
 }
+
+%%
+fmt.Printf("Hello! %s\n", c)
+fmt.Printf("math.Pi - PI=%f\n", math.Pi - float64(PI32))
 `
 
 func TestState_ParseFromMainGo(t *testing.T) {
@@ -113,7 +117,7 @@ func TestState_ParseFromMainGo(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create main.go: %+v", err)
 	}
-	err = s.ParseFromMainGo(nil, NoCursor, s.Decls)
+	err = s.parseFromMainGo(nil, NoCursor, s.Decls)
 	if err != nil {
 		t.Fatalf("Failed to parse imports from main.go: %+v", err)
 	}
@@ -304,7 +308,7 @@ func TestCursorPositioning(t *testing.T) {
 	}
 	for _, testLine := range testLines {
 		buf := bytes.NewBuffer(make([]byte, 0, 16384))
-		err = s.ParseFromMainGo(nil, testLine.cursor, s.Decls)
+		err = s.parseFromMainGo(nil, testLine.cursor, s.Decls)
 		if err != nil {
 			t.Fatalf("Failed to parse imports from main.go: %+v", err)
 		}

--- a/goexec/parser_test.go
+++ b/goexec/parser_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/gofrs/uuid"
-	"github.com/pkg/errors"
+	. "github.com/janpfeifer/gonb/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"os"
+	"strings"
 	"testing"
 )
 
@@ -24,21 +24,20 @@ func newEmptyState(t *testing.T) *State {
 }
 
 // createTestGoMain prefixes the cell content with `package main` and writes it to `main.go`.
-func createTestGoMain(s *State, cellContent string) error {
-	f, err := os.Create(s.MainPath())
-	if err != nil {
-		return errors.Wrapf(err, "Failed to create file %q", s.MainPath())
+func createTestGoMain(t *testing.T, s *State, cellContent string) (fileToCellLine []int) {
+	content := sampleCellCode
+	lines := strings.Split(content, "\n")
+	skipLines := MakeSet[int]()
+	for ii, line := range lines {
+		if line == "!echo nonono" {
+			skipLines.Insert(ii)
+		}
 	}
-	_, err = f.WriteString("package main\n\n" + cellContent)
-	if err != nil {
-		return errors.Wrapf(err, "Failed to write to file %q", s.MainPath())
-	}
-	err = f.Close()
-	if err != nil {
-		return errors.Wrapf(err, "Failed to close file %q", s.MainPath())
-	}
-	fmt.Printf("Create test data in %q\n", f.Name())
-	return nil
+
+	var err error
+	_, fileToCellLine, err = s.createGoFileFromLines(s.MainPath(), lines, skipLines, NoCursor)
+	require.NoErrorf(t, err, "Failed createGoFileFromLines(%q)", s.MainPath())
+	return
 }
 
 var (
@@ -106,27 +105,31 @@ func sum[T interface{int | float32 | float64}](a, b T) T {
 func init_c() {
 	c += ", blah"
 }
+
+!echo nonono
+
+%%
+fmt.Printf("Hello! %s\n", c)
+fmt.Printf("1 + 3 = %d\n", sum(1, 3))
+fmt.Printf("math.Pi - PI=%f\n", math.Pi - float64(PI32))
 `
 )
 
 func TestState_Parse(t *testing.T) {
 	s := newEmptyState(t)
-	defer func() {
-		err := s.Finalize()
-		if err != nil {
-			t.Fatalf("Failed to finalized state: %+v", err)
-		}
-	}()
+	//defer func() {
+	//	err := s.Finalize()
+	//	if err != nil {
+	//		t.Fatalf("Failed to finalized state: %+v", err)
+	//	}
+	//}()
+	fileToCellLine := createTestGoMain(t, s, sampleCellCode)
+	fmt.Printf("Code:\t%s\n", s.MainPath())
+
 	var err error
-	fmt.Printf("s.TempDir=%q\n", s.TempDir)
-	if err = createTestGoMain(s, sampleCellCode); err != nil {
-		t.Fatalf("Failed to create main.go: %+v", err)
-	}
-	fmt.Printf("s.TempDir=%q\n", s.TempDir)
-	s.Decls, err = s.parseFromMainGo(nil, NoCursor)
-	if err != nil {
-		t.Fatalf("Failed to parse imports from main.go: %+v", err)
-	}
+	s.Decls, err = s.parseFromMainGo(nil, -1, NoCursor, fileToCellLine)
+	require.NoErrorf(t, err, "Failed to parse %q", s.MainPath())
+
 	fmt.Printf("\ttest imports: %+v\n", s.Decls.Imports)
 	assert.Lenf(t, s.Decls.Imports, 5, "Expected 5 imports, got %+v", s.Decls.Imports)
 	assert.Contains(t, s.Decls.Imports, "fmt")
@@ -134,15 +137,21 @@ func TestState_Parse(t *testing.T) {
 	assert.Contains(t, s.Decls.Imports, "fmtOther")
 	assert.Contains(t, s.Decls.Imports, "errors")
 	assert.Contains(t, s.Decls.Imports, ".~gomlx/computation")
+	assert.ElementsMatch(t, []int{7}, s.Decls.Imports["errors"].CellLines.Lines,
+		"Index to line numbers in original cell don't match.")
 
 	fmt.Printf("\ttest functions: %+v\n", s.Decls.Functions)
-	assert.Lenf(t, s.Decls.Functions, 6, "Expected 2 functions, got %+v", s.Decls.Functions)
+	// Notice `func main` will be automatically included.
+	assert.Lenf(t, s.Decls.Functions, 7, "Expected 6 functions, got %d", len(s.Decls.Functions))
 	assert.Contains(t, s.Decls.Functions, "f")
 	assert.Contains(t, s.Decls.Functions, "sum")
 	assert.Contains(t, s.Decls.Functions, "init_c")
 	assert.Contains(t, s.Decls.Functions, "Kg~Weight")
 	assert.Contains(t, s.Decls.Functions, "Kg~Gain")
 	assert.Contains(t, s.Decls.Functions, "N~Weight")
+	assert.Contains(t, s.Decls.Functions, "main")
+	assert.ElementsMatch(t, []int{-1, -1, 68, 69, 70, 71, -1, -1}, s.Decls.Functions["main"].CellLines.Lines,
+		"Index to line numbers in original cell don't match.")
 
 	fmt.Printf("\ttest variables: %+v\n", s.Decls.Variables)
 	assert.Lenf(t, s.Decls.Variables, 6, "Expected 4 variables, got %+v", s.Decls.Variables)
@@ -152,6 +161,8 @@ func TestState_Parse(t *testing.T) {
 	assert.Contains(t, s.Decls.Variables, "b")
 	assert.Contains(t, s.Decls.Variables, "c")
 	// The 5th var is "_", which gets a random key.
+	assert.ElementsMatch(t, []int{21, 22}, s.Decls.Variables["b"].CellLines.Lines,
+		"Index to line numbers in original cell don't match.")
 
 	fmt.Printf("\ttest types: %+v\n", s.Decls.Types)
 	assert.Lenf(t, s.Decls.Types, 3, "Expected 3 types, got %+v", s.Decls.Types)
@@ -159,6 +170,8 @@ func TestState_Parse(t *testing.T) {
 	assert.Contains(t, s.Decls.Types, "Kg")
 	assert.Contains(t, s.Decls.Types, "N")
 	assert.Equal(t, "struct { x, y float64 }", s.Decls.Types["XY"].TypeDefinition)
+	assert.ElementsMatch(t, []int{27}, s.Decls.Types["XY"].CellLines.Lines,
+		"Index to line numbers in original cell don't match.")
 
 	fmt.Printf("\ttest constants: %+v\n", s.Decls.Constants)
 	assert.Lenf(t, s.Decls.Constants, 7, "Expected 7 Constants, got %+v", s.Decls.Constants)
@@ -172,6 +185,8 @@ func TestState_Parse(t *testing.T) {
 	assert.Contains(t, s.Decls.Constants, "K2")
 	assert.Equal(t, "K0", s.Decls.Constants["K1"].Prev.Key)
 	assert.Equal(t, "K2", s.Decls.Constants["K1"].Next.Key)
+	assert.ElementsMatch(t, []int{45}, s.Decls.Constants["K0"].CellLines.Lines,
+		"Index to line numbers in original cell don't match.")
 
 	// Check imports rendering.
 	wantImportsRendering := `import (
@@ -226,6 +241,15 @@ func f(x int) {
 
 func init() {
 	c += ", blah"
+}
+
+func main() {
+	flag.Parse()
+	fmt.Printf("Hello! %s\n", c)
+	fmt.Printf("1 + 3 = %d\n", sum(1, 3))
+	fmt.Printf("math.Pi - PI=%f\n", math.Pi - float64(PI32))
+
+
 }
 
 func sum[T interface{int | float32 | float64}](a, b T) T {
@@ -287,12 +311,8 @@ func TestCursorPositioning(t *testing.T) {
 			t.Fatalf("Failed to finalized state: %+v", err)
 		}
 	}()
-
+	fileToCellLine := createTestGoMain(t, s, sampleCellCode)
 	var err error
-	if err = createTestGoMain(s, sampleCellCode); err != nil {
-		t.Fatalf("Failed to create main.go: %+v", err)
-	}
-
 	testLines := []struct {
 		cursor Cursor
 		Line   string
@@ -320,7 +340,7 @@ func TestCursorPositioning(t *testing.T) {
 	}
 	for _, testLine := range testLines {
 		buf := bytes.NewBuffer(make([]byte, 0, 16384))
-		s.Decls, err = s.parseFromMainGo(nil, testLine.cursor)
+		s.Decls, err = s.parseFromMainGo(nil, -1, testLine.cursor, fileToCellLine)
 		if err != nil {
 			t.Fatalf("Failed to parse imports from main.go: %+v", err)
 		}

--- a/kernel/pipeexec.go
+++ b/kernel/pipeexec.go
@@ -82,11 +82,11 @@ func (builder *PipeExecToJupyterBuilder) WithPassword(millisecondsWait int) *Pip
 	return builder
 }
 
-// Run executes the configured PipeExecToJupyter configuration.
+// Exec executes the configured PipeExecToJupyter configuration.
 //
 // It returns an error if it failed to execute or created the pipes -- but not if the executed
 // program returns an error for any reason.
-func (builder *PipeExecToJupyterBuilder) Run() error {
+func (builder *PipeExecToJupyterBuilder) Exec() error {
 	log.Printf("Executing: %s %v", builder.command, builder.args)
 
 	cmd := exec.Command(builder.command, builder.args...)

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ func main() {
 	}
 
 	if *flagKernel == "" {
-		fmt.Fprintf(os.Stderr, "Use either --install to install the kernel, or if started by Jupyter the flag --kernel must be provided.\n")
+		_, _ = fmt.Fprintf(os.Stderr, "Use either --install to install the kernel, or if started by Jupyter the flag --kernel must be provided.\n")
 		flag.PrintDefaults()
 		os.Exit(1)
 	}
@@ -86,8 +86,8 @@ var (
 // SetUpLogging creates a UniqueID, uses it as a prefix for logging, and sets up --extra_log if
 // requested.
 func SetUpLogging() {
-	uuid, _ := uuid.NewV7()
-	uuidStr := uuid.String()
+	uuidTmp, _ := uuid.NewV7()
+	uuidStr := uuidTmp.String()
 	UniqueID = uuidStr[len(uuidStr)-8:]
 	log.SetPrefix(fmt.Sprintf("%s[%s]%s ", ColorBgYellow, UniqueID, ColorReset))
 	if *flagExtraLog != "" {
@@ -95,7 +95,7 @@ func SetUpLogging() {
 		if err != nil {
 			log.Fatalf("Failed to open log file %q for writing: %+v", *flagExtraLog, err)
 		}
-		f.Write([]byte("\n\n"))
+		_, _ = f.Write([]byte("\n\n"))
 		w := io.MultiWriter(f, os.Stderr) // Write to STDERR and the newly open f.
 		log.SetOutput(w)
 	}

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	flagInstall  = flag.Bool("install", false, "Install kernel in local config, and make it available in Jupyter")
-	flagKernel   = flag.String("kernel", "", "Run kernel using given path for the `connection_file` provided by Jupyter client")
+	flagKernel   = flag.String("kernel", "", "Exec kernel using given path for the `connection_file` provided by Jupyter client")
 	flagExtraLog = flag.String("extra_log", "", "Extra file to include in the log.")
 	flagForce    = flag.Bool("force", false, "Force install even if goimports and/or gopls are missing.")
 )

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -212,13 +212,13 @@ func execShell(msg kernel.Message, goExec *goexec.State, cmdStr string, status *
 	if status.withInputs {
 		status.withInputs = false
 		status.withPassword = false
-		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).WithInput(500).Run()
+		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).WithInput(500).Exec()
 	} else if status.withPassword {
 		status.withInputs = false
 		status.withPassword = false
-		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).WithPassword(1).Run()
+		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).WithPassword(1).Exec()
 	} else {
-		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).Run()
+		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).Exec()
 	}
 }
 

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -8,6 +8,7 @@ package specialcmd
 
 import (
 	"fmt"
+	. "github.com/janpfeifer/gonb/common"
 	"github.com/janpfeifer/gonb/goexec"
 	"github.com/janpfeifer/gonb/kernel"
 	"github.com/pkg/errors"
@@ -90,10 +91,10 @@ type cellStatus struct {
 // from the code will be returned in usedLines -- so they can be excluded from other executors (goexec).
 //
 // If any errors happen, it is returned in err.
-func Parse(msg kernel.Message, goExec *goexec.State, execute bool, codeLines []string, usedLines map[int]bool) (err error) {
+func Parse(msg kernel.Message, goExec *goexec.State, execute bool, codeLines []string, usedLines Set[int]) (err error) {
 	status := &cellStatus{}
 	for lineNum := 0; lineNum < len(codeLines); lineNum++ {
-		if usedLines[lineNum] {
+		if _, found := usedLines[lineNum]; found {
 			continue
 		}
 		line := codeLines[lineNum]
@@ -133,10 +134,10 @@ func Parse(msg kernel.Message, goExec *goexec.State, execute bool, codeLines []s
 //
 // It returns the joined lines with the '\\\n' replaced by a space, and appends the used lines (including
 // fromLine) to usedLines.
-func joinLine(lines []string, fromLine int, usedLines map[int]bool) (cmdStr string) {
+func joinLine(lines []string, fromLine int, usedLines Set[int]) (cmdStr string) {
 	for ; fromLine < len(lines); fromLine++ {
 		cmdStr += lines[fromLine]
-		usedLines[fromLine] = true
+		usedLines[fromLine] = struct{}{}
 		if cmdStr[len(cmdStr)-1] != '\\' {
 			return
 		}

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -212,13 +212,13 @@ func execShell(msg kernel.Message, goExec *goexec.State, cmdStr string, status *
 	if status.withInputs {
 		status.withInputs = false
 		status.withPassword = false
-		return kernel.PipeExecToJupyterWithInput(msg, execDir, "/bin/bash", "-c", cmdStr)
+		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).WithInput(500).Run()
 	} else if status.withPassword {
 		status.withInputs = false
 		status.withPassword = false
-		return kernel.PipeExecToJupyterWithPassword(msg, execDir, "/bin/bash", "-c", cmdStr)
+		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).WithPassword(1).Run()
 	} else {
-		return kernel.PipeExecToJupyter(msg, execDir, "/bin/bash", "-c", cmdStr)
+		return kernel.PipeExecToJupyter(msg, "/bin/bash", "-c", cmdStr).InDir(execDir).Run()
 	}
 }
 


### PR DESCRIPTION
* Improved error reporting, including indication of line number in cell.
* Parse error output of the execution of a cell, and if it contains a stack-trace, add a reference to the cell
  code (cell id and line number).
* Cleaned up, improved code documentation and testing for `goexec` package.
