### PR TITLE
* Added `go.work` support and %cd special command.

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -6,8 +6,11 @@ import (
 	"golang.org/x/exp/constraints"
 	"io/fs"
 	"os"
+	"os/user"
+	"path"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // Set implements a Set for the key type T.
@@ -84,4 +87,14 @@ func walkDirWithSymbolicLinksImpl(root, current string, dirFunc fs.WalkDirFunc, 
 		// If not a symbolic link, call the user's function.
 		return dirFunc(entryPath, info, err)
 	})
+}
+
+// ReplaceTildeInDir by the user's home directory. Returns dir if it doesn't start with "~".
+func ReplaceTildeInDir(dir string) string {
+	if dir != "~" && !strings.HasPrefix(dir, "~/") {
+		return dir
+	}
+	usr, _ := user.Current()
+	homeDir := usr.HomeDir
+	return path.Join(homeDir, dir[1:])
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GoNB Changelog
 
+## Next
+
+* Added "%cd" to chance current directory.
+
 ## v0.70.0 - 2023/05/29
 
 * Added "%ls" and "%rm" to manage memorized definitions directly.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-* Added "%cd" to chance current directory.
+* Added special command `%cd` to chance current directory.
+* Commands `%cd` and `%env` prints results of its execution.
 
 ## v0.70.0 - 2023/05/29
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Next
 
+* Added support for tracking `go.work`, which allows auto-complete and contextual help
+  to work with the local modules configured. It also requires `gopls` _v0.12.4_ or newer to work.
+* Fixed auto-complete bug when no `main` function (or no `%%`) was present in cell.
 * Added special command `%cd` to chance current directory.
 * Commands `%cd` and `%env` prints results of its execution.
 

--- a/goexec/execcode.go
+++ b/goexec/execcode.go
@@ -7,6 +7,7 @@ import (
 	"github.com/janpfeifer/gonb/kernel"
 	"github.com/pkg/errors"
 	"io"
+	"k8s.io/klog/v2"
 	"log"
 	"os/exec"
 	"path"
@@ -88,6 +89,7 @@ func (s *State) Compile(msg kernel.Message, fileToCellIdAndLines []CellIdAndLine
 //
 // It returns the updated cursorInFile and fileToCellIdAndLines that reflect any changes in `main.go`.
 func (s *State) GoImports(msg kernel.Message, decls *Declarations, mainDecl *Function, fileToCellIdAndLine []CellIdAndLine) (cursorInFile Cursor, updatedFileToCellIdAndLine []CellIdAndLine, err error) {
+	klog.V(2).Infof("GoImports():")
 	cursorInFile = NoCursor
 	goimportsPath, err := exec.LookPath("goimports")
 	if err != nil {
@@ -142,6 +144,7 @@ can install it from the notebook with:
 		err = errors.WithMessagef(err, "while composing main.go with all declarations")
 		return
 	}
+	klog.V(2).Infof("GoImports(): cursorInFile=%s", cursorInFile)
 
 	// Download missing dependencies.
 	if !s.AutoGet {

--- a/goexec/goplsclient/conn.go
+++ b/goexec/goplsclient/conn.go
@@ -395,7 +395,7 @@ func (h *jsonrpc2Handler) Deliver(ctx context.Context, r *jsonrpc2.Request, deli
 			klog.Errorf("Failed to parse LogMessageParams: %v", err)
 			return true
 		}
-		klog.V(2).Infof("received gopls window log message: %q", trimString(params.Message, 100))
+		klog.V(2).Infof("received gopls window log message: %s", params.Message)
 		return true
 	case lsp.MethodTextDocumentPublishDiagnostics:
 		var params lsp.PublishDiagnosticsParams
@@ -408,7 +408,9 @@ func (h *jsonrpc2Handler) Deliver(ctx context.Context, r *jsonrpc2.Request, deli
 		for _, diag := range params.Diagnostics {
 			h.client.messages = append(h.client.messages, diag.Message)
 		}
-		klog.V(2).Infof("received gopls diagnostics: %+v", trimString(fmt.Sprintf("%+v", params), 100))
+		if (klog.V(2).Enabled() && len(params.Diagnostics) > 0) || klog.V(3).Enabled() {
+			klog.V(2).Infof("received gopls diagnostics: %+v", trimString(fmt.Sprintf("%+v", params), 100))
+		}
 		return true
 	default:
 		klog.Errorf("gopls jsonrpc2 delivered but not handled: %q", r.Method)
@@ -428,7 +430,6 @@ func (h *jsonrpc2Handler) Cancel(ctx context.Context, conn *jsonrpc2.Conn, id js
 // Request implements jsonrpc2.Handler.
 func (h *jsonrpc2Handler) Request(ctx context.Context, conn *jsonrpc2.Conn, direction jsonrpc2.Direction, r *jsonrpc2.WireRequest) context.Context {
 	_ = conn
-	_ = direction
 	klog.V(2).Infof("jsonrpc2 Request(direction=%s) %q", direction, r.Method)
 	return ctx
 }

--- a/goexec/inspect.go
+++ b/goexec/inspect.go
@@ -36,7 +36,7 @@ func (s *State) notifyAboutStandardAndTrackedFiles(ctx context.Context) (err err
 	}
 
 	err = s.EnumerateUpdatedFiles(func(filePath string) error {
-		klog.Infof("Notified of change to %q", filePath)
+		klog.V(1).Infof("Notified of change to %q", filePath)
 		return s.gopls.NotifyDidOpenOrChange(ctx, filePath)
 	})
 	if err != nil {

--- a/goexec/inspect.go
+++ b/goexec/inspect.go
@@ -123,7 +123,7 @@ func (s *State) InspectIdentifierInCell(lines []string, skipLines map[int]struct
 	return
 }
 
-// AutoCompleteOptionsInCell implements an `complete_request` from Jupyter, using `gopls`.
+// AutoCompleteOptionsInCell implements a `complete_request` from Jupyter, using `gopls`.
 // It updates `main.go` with the cell contents (given as lines)
 func (s *State) AutoCompleteOptionsInCell(cellLines []string, skipLines map[int]struct{},
 	cursorLine, cursorCol int, reply *kernel.CompleteReply) (err error) {

--- a/goexec/parser.go
+++ b/goexec/parser.go
@@ -427,11 +427,11 @@ func (s *State) parseLinesAndComposeMain(msg kernel.Message, cellId int, lines [
 		return
 	}
 	if cursorInCell.HasCursor() && !cursorInFile.HasCursor() {
-		// Returns empty data, which returns a "not found".
+		// Returns empty data, which returns a "not found."
 		err = errors.WithStack(CursorLost)
 		return
 	}
-	if cursorInCell.HasCursor() {
+	if cursorInCell.HasCursor() && klog.V(1).Enabled() {
 		s.logCursor(cursorInFile)
 	}
 	return

--- a/goexec/parser.go
+++ b/goexec/parser.go
@@ -404,7 +404,14 @@ func (s *State) parseLinesAndComposeMain(msg kernel.Message, cellId int, lines [
 		delete(newDecls.Functions, "main")
 	} else {
 		// Declare a stub main function, just so we can try to compile the final code.
-		mainDecl = &Function{Key: "main", Name: "main", Definition: "func main() { flag.Parse() }"}
+		mainDecl = &Function{
+			Cursor:     NoCursor,
+			CellLines:  CellLines{},
+			Key:        "main",
+			Name:       "main",
+			Receiver:   "",
+			Definition: "func main() { flag.Parse() }",
+		}
 	}
 
 	// Merge cell declarations with a copy of the current state: we don't want to commit the new

--- a/goexec/tracking.go
+++ b/goexec/tracking.go
@@ -4,6 +4,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/janpfeifer/gonb/common"
 	"github.com/pkg/errors"
+	"golang.org/x/mod/modfile"
 	"io/fs"
 	"k8s.io/klog/v2"
 	"os"
@@ -32,8 +33,8 @@ type trackingInfo struct {
 	// watcher for files being tracked. It is notified of file system changes.
 	watcher *fsnotify.Watcher
 
-	// go.mod last modification time, used for the AutoTrack
-	goModModTime time.Time
+	// go.mod and go.work last modification time, used for the AutoTrack
+	goModModTime, goWorkModTime time.Time
 }
 
 // trackEntry has information about a file or directory.
@@ -269,16 +270,26 @@ func (s *State) EnumerateUpdatedFiles(fn func(filePath string) error) (err error
 	return
 }
 
-// AutoTrack adds automatic tracked directories. It looks at go.mod for
+// AutoTrack adds automatic tracked directories. It looks at go.mod and go.work for
 // redirects to the local filesystem.
-// TODO: add support for go.work as well.
 func (s *State) AutoTrack() (err error) {
+	klog.V(2).Infof("AutoTrack(): ...")
+	err = s.autoTrackGoMod()
+	if err != nil {
+		return
+	}
+	err = s.autoTrackGoWork()
+	return
+}
+
+// autoTrackGoMod tracks entries in `go.mod`.
+func (s *State) autoTrackGoMod() (err error) {
 	ti := s.trackingInfo
 	goModPath := path.Join(s.TempDir, "go.mod")
 	fileInfo, err := os.Stat(goModPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// No go.mod, we dont' auto-track anything.
+			// No go.mod, we don't auto-track anything.
 			err = nil
 			return
 		}
@@ -301,7 +312,7 @@ func (s *State) AutoTrack() (err error) {
 	for _, match := range matches {
 		replaceTarget := string(match[1])
 		if replaceTarget[0] != '/' {
-			// We only auto-track if the target of the replace is a local directory.
+			// We only auto-track if the target of the "replace" rule is a local directory.
 			continue
 		}
 		_, found := ti.tracked[replaceTarget]
@@ -340,3 +351,68 @@ var (
 	// `(?m)` makes "^" and "$" match beginning and end of line.
 	regexpGoModReplace = regexp.MustCompile(`(?m)^\s*replace\s+.*?=>\s+(.*)$`)
 )
+
+// autoTrackGoWork tracks entries in `go.work`.
+func (s *State) autoTrackGoWork() (err error) {
+	ti := s.trackingInfo
+	goWorkPath := path.Join(s.TempDir, "go.work")
+	fileInfo, err := os.Stat(goWorkPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No go.work, we don't auto-track anything.
+			err = nil
+			return
+		}
+		err = errors.Wrapf(err, "failed to check %q for auto-tracking of files", goWorkPath)
+		return
+	}
+	if !fileInfo.ModTime().After(ti.goWorkModTime) {
+		// No changes.
+		return
+	}
+
+	ti.goWorkModTime = fileInfo.ModTime()
+	klog.V(2).Infof("goexec.AutoTrack: re-parsing %q for changes at %s", goWorkPath, ti.goWorkModTime)
+	contents, err := os.ReadFile(goWorkPath)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to read %q for auto-tracking of files", goWorkPath)
+		return
+	}
+	workFile, err := modfile.ParseWork(goWorkPath, contents, nil)
+	if err != nil {
+		err = errors.Wrapf(err, "failed to parse %q for auto-tracking files", goWorkPath)
+		return
+	}
+	for _, useRule := range workFile.Use {
+		p := useRule.Path
+		_, found := ti.tracked[p]
+		if found {
+			// already tracked.
+			continue
+		}
+		klog.Infof("- go.work new replace: %s", p)
+		err = s.Track(p)
+
+		// Because fsnotify doesn't support recursion in watching for changes in subdirectories,
+		// we need to add each subdirectory under the one defined.
+		err = common.WalkDirWithSymbolicLinks(p, func(entryPath string, info fs.DirEntry, err error) error {
+			// Visit function for each file in the directory:
+			if err != nil {
+				return errors.Wrapf(err, "failed to auto-track file under directory %q", p)
+			}
+			if !isGoRelated(entryPath) {
+				return nil
+			}
+
+			// Only track directories that have go files. Notice repeated tracked directories
+			// are quickly ignored.
+			dir := path.Dir(entryPath)
+			return s.Track(dir)
+		})
+		if err != nil {
+			klog.Errorf("Failed to auto-track subdirectories of %q: %+v", p, err)
+			err = nil
+		}
+	}
+	return
+}

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -200,14 +200,18 @@ func execInternal(msg kernel.Message, goExec *goexec.State, cmdStr string, statu
 
 	case "cd":
 		if len(parts) != 2 {
+			pwd, _ := os.Getwd()
+			_ = kernel.PublishWriteStream(msg, kernel.StreamStdout,
+				fmt.Sprintf("Current directory: %q\n", pwd))
 			return errors.Errorf("`%%cd <directory>`: it takes one argument, but %d were given", len(parts)-1)
 		}
-		err := os.Chdir(parts[1])
+		err := os.Chdir(ReplaceTildeInDir(parts[1]))
 		if err != nil {
 			return errors.Wrapf(err, "`%%cd %q` failed", parts[1])
 		}
+		pwd, _ := os.Getwd()
 		err = kernel.PublishWriteStream(msg, kernel.StreamStdout,
-			fmt.Sprintf("Changed directory to %q\n", parts[1]))
+			fmt.Sprintf("Changed directory to %q\n", pwd))
 		if err != nil {
 			klog.Errorf("Failed to output: %+v", err)
 		}

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -56,6 +56,8 @@ Special non-Go commands:
   overwrite the values here.
 - "%autoget" and "%noautoget": Default is "%autoget", which automatically does "go get" for
   packages not yet available.
+- "%cd [<directory>]": Change current directory of the Go kernel, and the directory from where
+  the cells are executed. If no directory is given it reports the current directory.
 - "%env VAR value": Sets the environment variable VAR to the given value. These variables
   will be available both for Go code as well as for shell scripts.
 - "%with_inputs": will prompt for inputs for the next shell command. Use this if
@@ -199,11 +201,13 @@ func execInternal(msg kernel.Message, goExec *goexec.State, cmdStr string, statu
 		}
 
 	case "cd":
-		if len(parts) != 2 {
+		if len(parts) == 1 {
 			pwd, _ := os.Getwd()
 			_ = kernel.PublishWriteStream(msg, kernel.StreamStdout,
 				fmt.Sprintf("Current directory: %q\n", pwd))
-			return errors.Errorf("`%%cd <directory>`: it takes one argument, but %d were given", len(parts)-1)
+		}
+		if len(parts) > 2 {
+			return errors.Errorf("`%%cd [<directory>]`: it takes none or one argument, but %d were given", len(parts)-1)
 		}
 		err := os.Chdir(ReplaceTildeInDir(parts[1]))
 		if err != nil {


### PR DESCRIPTION
* Added support for tracking `go.work`, which allows auto-complete and contextual help
  to work with the local modules configured. It also requires `gopls` _v0.12.4_ or newer to work.
* Fixed auto-complete bug when no `main` function (or no `%%`) was present in cell.
* Added special command `%cd` to chance current directory.
* Commands `%cd` and `%env` prints results of its execution.

Fixes issue report in #30 
