### PR TITLE
v0.7.7: Fixed Init; Added markdown support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN apt-get install --yes --no-install-recommends git
 #######################################################################################################
 # Go and GoNB Libraries
 #######################################################################################################
-ENV GO_VERSION=1.20.4
-ENV GONB_VERSION="v0.7.6"
+ENV GO_VERSION=1.20.5
+ENV GONB_VERSION="v0.7.7"
 ENV GOROOT=/usr/local/go
 ENV GOPATH=${HOME}/go
 ENV PATH=$PATH:$GOROOT/bin:$GOPATH/bin

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,6 @@
 # GoNB Changelog
 
-## Next
+## 0.7.7 -- 2023/08/08
 
 * Added `DisplayMarkdown` and `UpdateMarkdown`.
 * Changed `%help` to use markdown.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GoNB Changelog
 
+## Next
+
+* `init_*` functions: fixed duplicate rendering;
+
 ## 0.7.6 -- 2023/07/28
 
 * Issue #43:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Next
 
+* Added `DisplayMarkdown` and `UpdateMarkdown`.
+* Changed `%help` to use markdown.
 * `init_*` functions: 
   * Fixed duplicate rendering.
   * Added section about it in `tutorial.ipynb`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## Next
 
-* `init_*` functions: fixed duplicate rendering;
+* `init_*` functions: 
+  * Fixed duplicate rendering.
+  * Added section about it in `tutorial.ipynb`
+* Updated tutorial to used `%rm` to remove no longer wanted definitions.
 
 ## 0.7.6 -- 2023/07/28
 

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -207,7 +207,7 @@
      "output_type": "stream",
      "text": [
       "\t...VeryExpensive() call...\n",
-      "NonCachedValue=792\n",
+      "NonCachedValue=950\n",
       "   CachedValue=319\n"
      ]
     }
@@ -292,7 +292,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 100% |████████████████████████████████████████| (25 steps/s) [3s:0s]0s]\n",
+      " 100% |████████████████████████████████████████| (25 steps/s) [3s:0s]:0s]\n",
       "Done\n"
      ]
     }
@@ -353,6 +353,42 @@
   },
   {
    "cell_type": "markdown",
+   "id": "31d7080f-d94d-4e2d-92d8-e8173244c21c",
+   "metadata": {},
+   "source": [
+    "### Markdown\n",
+    "\n",
+    "It is also supported -- and used for the `%help` command, see the bottom of the tutorial.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "9b76a18c-faa8-449e-b56a-8453de99dbc3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/markdown": [
+       "#### Objective\n",
+       "\n",
+       "1. Have fun coding in **Go**;\n",
+       "1. Profit...\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "%%\n",
+    "gonbui.DisplayMarkdown(\"#### Objective\\n\\n1. Have fun coding in **Go**;\\n1. Profit...\\n\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "78f82dcb-3bf4-4c43-8f41-3b8dc3fe3461",
    "metadata": {},
    "source": [
@@ -363,7 +399,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "id": "e5f298cd-a260-493c-9c59-dd3d79706116",
    "metadata": {},
    "outputs": [
@@ -371,7 +407,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "lastRenderTime=1.979382\n"
+      "lastRenderTime=2.030664\n"
      ]
     },
     {
@@ -429,7 +465,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 13,
    "id": "48d813a8-8d4e-4ab7-b374-10a73977ec7b",
    "metadata": {},
    "outputs": [
@@ -571,7 +607,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 14,
    "id": "1fda7399-ecb1-44c2-b05c-fb52d188822a",
    "metadata": {},
    "outputs": [
@@ -589,14 +625,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 15,
    "id": "6904a8ef-5a4c-412f-ad75-58910d933b76",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/html": [
-       "<div><svg viewbox=\"0 0 640 480\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"640\" height=\"480\"><defs><marker markerWidth=\"2%\" markerHeight=\"2%\" id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\"><circle r=\"3\" fill=\"none\" stroke=\"black\" cx=\"5\" cy=\"5\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \"><circle fill=\"black\" stroke=\"none\" cx=\"5\" cy=\"5\" r=\"3\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"square\" viewBox=\"0 0 10 10 \"><rect y=\"2\" width=\"6\" height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\"><rect height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\" y=\"2\" width=\"6\"/></marker></defs><g fill=\"none\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-linejoin=\"round\" marker-end=\"url(#square)\" marker-start=\"url(#square)\" stroke=\"hsl(90, 47%, 65%)\" stroke-width=\"1px\" marker-mid=\"url(#square)\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,6.800000e+00 L6.333333e+01,4.306667e+01 L1.166667e+02,7.933333e+01 L170,1.156000e+02 L2.233333e+02,1.518667e+02 L2.766667e+02,1.881333e+02 L330,2.244000e+02 L3.833333e+02,2.606667e+02 L4.366667e+02,2.969333e+02 L490,3.332000e+02 \"/></g><g stroke=\"hsl(301, 88%, 65%)\" stroke-width=\"3.14px\" stroke-linejoin=\"round\" fill=\"none\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,6.800000e+00 C1.888889e+01,6.875434e+00 4.555556e+01,7.018758e+00 6.333333e+01,7.252602e+00 C8.111111e+01,7.486446e+00 9.888889e+01,7.711993e+00 1.166667e+02,8.203066e+00 C1.344444e+02,8.694139e+00 1.522222e+02,9.167786e+00 1.700000e+02,1.019904e+01 C1.877778e+02,1.123029e+01 2.055556e+02,1.222495e+01 2.233333e+02,1.439059e+01 C2.411111e+02,1.655622e+01 2.588889e+02,1.864500e+01 2.766667e+02,2.319283e+01 C2.944444e+02,2.774066e+01 3.122222e+02,3.212711e+01 3.300000e+02,4.167755e+01 C3.477778e+02,5.122798e+01 3.655556e+02,6.043953e+01 3.833333e+02,8.049545e+01 C4.011111e+02,1.005514e+02 4.188889e+02,1.198956e+02 4.366667e+02,1.620130e+02 C4.544444e+02,2.041305e+02 4.811111e+02,3.046688e+02 4.900000e+02,3.332000e+02 \"/></g><g marker-mid=\"url(#filled-circle)\" stroke-linecap=\"round\" marker-start=\"url(#filled-circle)\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-linejoin=\"round\" fill=\"none\" stroke=\"hsl(152, 76%, 65%)\" stroke-width=\"3px\" marker-end=\"url(#filled-circle)\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,2.238017e+02 C1.888889e+01,2.333421e+02 4.555556e+01,2.723836e+02 6.333333e+01,2.810439e+02 C8.111111e+01,2.897043e+02 9.888889e+01,2.842325e+02 1.166667e+02,2.757638e+02 C1.344444e+02,2.672951e+02 1.522222e+02,2.452773e+02 1.700000e+02,2.302318e+02 C1.877778e+02,2.151863e+02 2.055556e+02,1.787898e+02 2.233333e+02,1.854907e+02 C2.411111e+02,1.921916e+02 2.588889e+02,2.665045e+02 2.766667e+02,2.704371e+02 C2.944444e+02,2.743696e+02 3.122222e+02,2.156400e+02 3.300000e+02,2.090860e+02 C3.477778e+02,2.025320e+02 3.655556e+02,2.381129e+02 3.833333e+02,2.311130e+02 C4.011111e+02,2.241130e+02 4.188889e+02,1.615127e+02 4.366667e+02,1.670862e+02 C4.544444e+02,1.726597e+02 4.811111e+02,2.483094e+02 4.900000e+02,2.645540e+02 \"/></g><g stroke=\"black\" stroke-width=\"2px\" stroke-linejoin=\"round\" fill=\"none\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,0 L10,-6 M6.333333e+01,0 L6.333333e+01,-6 M1.166667e+02,0 L1.166667e+02,-6 M170,0 L170,-6 M2.233333e+02,0 L2.233333e+02,-6 M2.766667e+02,0 L2.766667e+02,-6 M330,0 L330,-6 M3.833333e+02,0 L3.833333e+02,-6 M4.366667e+02,0 L4.366667e+02,-6 M490,0 L490,-6 \"/></g><g stroke-linecap=\"round\" fill=\"black\" font-style=\"normal\" text-anchor=\"middle\" stroke-width=\"2px\" stroke-linejoin=\"round\" font-weight=\"normal\" transform=\"translate(70 410 )scale(1 1 )\" font-family=\"sans-serif\" font-size=\"12px\" dominant-baseline=\"hanging\" stroke=\"black\"><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"10\" y=\"10\">1</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"6.333333e+01\">2</text><text vector-effect=\"non-scaling-stroke\" x=\"1.166667e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">3</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"10\" dominant-baseline=\"hanging\">4</text><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.233333e+02\" y=\"10\">5</text><text vector-effect=\"non-scaling-stroke\" x=\"2.766667e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">6</text><text x=\"330\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">7</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"3.833333e+02\" y=\"10\" dominant-baseline=\"hanging\">8</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"4.366667e+02\" y=\"10\" dominant-baseline=\"hanging\">9</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"490\" y=\"10\" dominant-baseline=\"hanging\">10</text></g><g stroke-width=\"2px\" stroke-linejoin=\"round\" font-style=\"normal\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )rotate(0 0 0 )\" stroke=\"black\" dominant-baseline=\"baseline\" font-family=\"sans-serif\" font-size=\"12px\" text-anchor=\"middle\" fill=\"black\" font-weight=\"bold\"><text y=\"-6\" dominant-baseline=\"baseline\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"250\">X</text></g><g font-weight=\"bold\" stroke=\"black\" stroke-width=\"2px\" stroke-linejoin=\"round\" font-size=\"12px\" font-style=\"normal\" transform=\"translate(70 410 )scale(1 -1 )\" dominant-baseline=\"baseline\" font-family=\"sans-serif\" text-anchor=\"middle\" fill=\"black\" stroke-linecap=\"round\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L-6,2.472591e+01 M0,5.860766e+01 L-6,5.860766e+01 M0,9.248942e+01 L-6,9.248942e+01 M0,1.263712e+02 L-6,1.263712e+02 M0,1.602529e+02 L-6,1.602529e+02 M0,1.941347e+02 L-6,1.941347e+02 M0,2.280164e+02 L-6,2.280164e+02 M0,2.618982e+02 L-6,2.618982e+02 M0,2.957799e+02 L-6,2.957799e+02 M0,3.296617e+02 L-6,3.296617e+02 \"/></g><g dominant-baseline=\"middle\" font-style=\"normal\" text-anchor=\"end\" font-family=\"sans-serif\" stroke=\"black\" stroke-linejoin=\"round\" font-weight=\"normal\" fill=\"black\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )\" font-size=\"12px\" stroke-width=\"2px\"><text x=\"-10\" y=\"-2.472591e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">1.0</text><text y=\"-5.860766e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">2.0</text><text y=\"-9.248942e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">4.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.263712e+02\" dominant-baseline=\"middle\">8.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.602529e+02\" dominant-baseline=\"middle\">16.0</text><text vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.941347e+02\" dominant-baseline=\"middle\" stroke=\"none\">32.0</text><text vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.280164e+02\" dominant-baseline=\"middle\" stroke=\"none\">64.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.618982e+02\" dominant-baseline=\"middle\">128.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.957799e+02\" dominant-baseline=\"middle\">256.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-3.296617e+02\" dominant-baseline=\"middle\">512.0</text></g><g stroke=\"black\" font-family=\"sans-serif\" font-style=\"normal\" stroke-linejoin=\"round\" font-weight=\"bold\" transform=\"translate(70 410 )scale(1 1 )rotate(-90 0 0 )\" font-size=\"12px\" text-anchor=\"middle\" fill=\"black\" stroke-linecap=\"round\" dominant-baseline=\"hanging\" stroke-width=\"2px\"><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"6\">Y</text></g><g text-anchor=\"middle\" fill=\"black\" stroke-linecap=\"round\" font-weight=\"bold\" stroke=\"gray\" stroke-width=\"0.5px\" stroke-linejoin=\"round\" dominant-baseline=\"hanging\" font-style=\"normal\" transform=\"translate(70 410 )scale(1 -1 )\" font-family=\"sans-serif\" font-size=\"12px\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L500,2.472591e+01 M0,5.860766e+01 L500,5.860766e+01 M0,9.248942e+01 L500,9.248942e+01 M0,1.263712e+02 L500,1.263712e+02 M0,1.602529e+02 L500,1.602529e+02 M0,1.941347e+02 L500,1.941347e+02 M0,2.280164e+02 L500,2.280164e+02 M0,2.618982e+02 L500,2.618982e+02 M0,2.957799e+02 L500,2.957799e+02 M0,3.296617e+02 L500,3.296617e+02 \"/></g><g font-weight=\"bold\" fill=\"none\" font-family=\"sans-serif\" font-size=\"12px\" stroke-linecap=\"round\" stroke=\"black\" stroke-width=\"2px\" stroke-linejoin=\"round\" dominant-baseline=\"hanging\" font-style=\"normal\" text-anchor=\"middle\"><rect x=\"70\" y=\"70\" width=\"500\" height=\"340\" vector-effect=\"non-scaling-stroke\"/><g dominant-baseline=\"middle\" font-size=\"18px\" fill=\"black\"><text vector-effect=\"non-scaling-stroke\" x=\"320\" y=\"35\" dominant-baseline=\"middle\" stroke=\"none\">A diagram of sorts 📊 📈</text></g></g></svg></div>"
+       "<div><svg preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"640\" height=\"480\" viewbox=\"0 0 640 480\" style=\"background-color:#f8f8f8\"><defs><marker id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><circle fill=\"none\" stroke=\"black\" cx=\"5\" cy=\"5\" r=\"3\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\"><circle fill=\"black\" stroke=\"none\" cx=\"5\" cy=\"5\" r=\"3\"/></marker><marker id=\"square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><rect x=\"2\" y=\"2\" width=\"6\" height=\"6\" fill=\"none\" stroke=\"black\"/></marker><marker markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\"><rect x=\"2\" y=\"2\" width=\"6\" height=\"6\" fill=\"black\" stroke=\"none\"/></marker></defs><g fill=\"none\" stroke=\"hsl(90, 47%, 65%)\" stroke-width=\"1px\" marker-start=\"url(#square)\" marker-end=\"url(#square)\" stroke-linejoin=\"round\" stroke-linecap=\"round\" marker-mid=\"url(#square)\" transform=\"translate(70 410 )scale(1 -1 )\"><path d=\"M10,6.800000e+00 L6.333333e+01,4.306667e+01 L1.166667e+02,7.933333e+01 L170,1.156000e+02 L2.233333e+02,1.518667e+02 L2.766667e+02,1.881333e+02 L330,2.244000e+02 L3.833333e+02,2.606667e+02 L4.366667e+02,2.969333e+02 L490,3.332000e+02 \" vector-effect=\"non-scaling-stroke\"/></g><g stroke=\"hsl(301, 88%, 65%)\" stroke-width=\"3.14px\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-linejoin=\"round\" fill=\"none\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,6.800000e+00 C1.888889e+01,6.875434e+00 4.555556e+01,7.018758e+00 6.333333e+01,7.252602e+00 C8.111111e+01,7.486446e+00 9.888889e+01,7.711993e+00 1.166667e+02,8.203066e+00 C1.344444e+02,8.694139e+00 1.522222e+02,9.167786e+00 1.700000e+02,1.019904e+01 C1.877778e+02,1.123029e+01 2.055556e+02,1.222495e+01 2.233333e+02,1.439059e+01 C2.411111e+02,1.655622e+01 2.588889e+02,1.864500e+01 2.766667e+02,2.319283e+01 C2.944444e+02,2.774066e+01 3.122222e+02,3.212711e+01 3.300000e+02,4.167755e+01 C3.477778e+02,5.122798e+01 3.655556e+02,6.043953e+01 3.833333e+02,8.049545e+01 C4.011111e+02,1.005514e+02 4.188889e+02,1.198956e+02 4.366667e+02,1.620130e+02 C4.544444e+02,2.041305e+02 4.811111e+02,3.046688e+02 4.900000e+02,3.332000e+02 \"/></g><g stroke-width=\"3px\" stroke-linecap=\"round\" marker-mid=\"url(#filled-circle)\" marker-end=\"url(#filled-circle)\" transform=\"translate(70 410 )scale(1 -1 )\" fill=\"none\" stroke-linejoin=\"round\" marker-start=\"url(#filled-circle)\" stroke=\"hsl(152, 76%, 65%)\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,8.730674e+01 C1.888889e+01,1.188814e+02 4.555556e+01,2.445732e+02 6.333333e+01,2.767547e+02 C8.111111e+01,3.089362e+02 9.888889e+01,2.908801e+02 1.166667e+02,2.803957e+02 C1.344444e+02,2.699114e+02 1.522222e+02,2.141433e+02 1.700000e+02,2.138486e+02 C1.877778e+02,2.135538e+02 2.055556e+02,2.692881e+02 2.233333e+02,2.786272e+02 C2.411111e+02,2.879663e+02 2.588889e+02,2.758245e+02 2.766667e+02,2.698832e+02 C2.944444e+02,2.639419e+02 3.122222e+02,2.458940e+02 3.300000e+02,2.429793e+02 C3.477778e+02,2.400645e+02 3.655556e+02,2.783876e+02 3.833333e+02,2.523947e+02 C4.011111e+02,2.264018e+02 4.188889e+02,8.341570e+01 4.366667e+02,8.702167e+01 C4.544444e+02,9.062763e+01 4.811111e+02,2.428623e+02 4.900000e+02,2.740305e+02 \"/></g><g stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-linejoin=\"round\" fill=\"none\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,0 L10,-6 M6.333333e+01,0 L6.333333e+01,-6 M1.166667e+02,0 L1.166667e+02,-6 M170,0 L170,-6 M2.233333e+02,0 L2.233333e+02,-6 M2.766667e+02,0 L2.766667e+02,-6 M330,0 L330,-6 M3.833333e+02,0 L3.833333e+02,-6 M4.366667e+02,0 L4.366667e+02,-6 M490,0 L490,-6 \"/></g><g font-style=\"normal\" fill=\"black\" stroke-linejoin=\"round\" font-family=\"sans-serif\" font-weight=\"normal\" text-anchor=\"middle\" transform=\"translate(70 410 )scale(1 1 )\" font-size=\"12px\" dominant-baseline=\"hanging\" stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"10\" y=\"10\" dominant-baseline=\"hanging\">1</text><text x=\"6.333333e+01\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">2</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"1.166667e+02\">3</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"10\" dominant-baseline=\"hanging\">4</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.233333e+02\">5</text><text x=\"2.766667e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">6</text><text x=\"330\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">7</text><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"3.833333e+02\" y=\"10\">8</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"4.366667e+02\" y=\"10\" dominant-baseline=\"hanging\">9</text><text vector-effect=\"non-scaling-stroke\" x=\"490\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">10</text></g><g stroke-linecap=\"round\" font-style=\"normal\" dominant-baseline=\"baseline\" fill=\"black\" font-weight=\"bold\" stroke-linejoin=\"round\" stroke=\"black\" stroke-width=\"2px\" transform=\"translate(70 410 )scale(1 1 )rotate(0 0 0 )\" font-size=\"12px\" font-family=\"sans-serif\" text-anchor=\"middle\"><text x=\"250\" y=\"-6\" dominant-baseline=\"baseline\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">X</text></g><g stroke-width=\"2px\" font-style=\"normal\" font-family=\"sans-serif\" font-weight=\"bold\" text-anchor=\"middle\" fill=\"black\" font-size=\"12px\" dominant-baseline=\"baseline\" stroke-linejoin=\"round\" stroke=\"black\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L-6,2.472591e+01 M0,5.860766e+01 L-6,5.860766e+01 M0,9.248942e+01 L-6,9.248942e+01 M0,1.263712e+02 L-6,1.263712e+02 M0,1.602529e+02 L-6,1.602529e+02 M0,1.941347e+02 L-6,1.941347e+02 M0,2.280164e+02 L-6,2.280164e+02 M0,2.618982e+02 L-6,2.618982e+02 M0,2.957799e+02 L-6,2.957799e+02 M0,3.296617e+02 L-6,3.296617e+02 \"/></g><g text-anchor=\"end\" dominant-baseline=\"middle\" stroke-width=\"2px\" stroke-linecap=\"round\" stroke-linejoin=\"round\" font-weight=\"normal\" transform=\"translate(70 410 )scale(1 1 )\" font-size=\"12px\" font-style=\"normal\" fill=\"black\" stroke=\"black\" font-family=\"sans-serif\"><text vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.472591e+01\" dominant-baseline=\"middle\" stroke=\"none\">1.0</text><text x=\"-10\" y=\"-5.860766e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">2.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-9.248942e+01\" dominant-baseline=\"middle\">4.0</text><text vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.263712e+02\" dominant-baseline=\"middle\" stroke=\"none\">8.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.602529e+02\" dominant-baseline=\"middle\">16.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.941347e+02\" dominant-baseline=\"middle\">32.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.280164e+02\">64.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.618982e+02\">128.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.957799e+02\" dominant-baseline=\"middle\">256.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-3.296617e+02\">512.0</text></g><g stroke-linecap=\"round\" text-anchor=\"middle\" font-size=\"12px\" dominant-baseline=\"hanging\" stroke=\"black\" fill=\"black\" stroke-width=\"2px\" transform=\"translate(70 410 )scale(1 1 )rotate(-90 0 0 )\" stroke-linejoin=\"round\" font-family=\"sans-serif\" font-weight=\"bold\" font-style=\"normal\"><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"6\">Y</text></g><g font-family=\"sans-serif\" font-weight=\"bold\" fill=\"black\" stroke-width=\"0.5px\" transform=\"translate(70 410 )scale(1 -1 )\" font-size=\"12px\" font-style=\"normal\" stroke-linejoin=\"round\" text-anchor=\"middle\" stroke=\"gray\" stroke-linecap=\"round\" dominant-baseline=\"hanging\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L500,2.472591e+01 M0,5.860766e+01 L500,5.860766e+01 M0,9.248942e+01 L500,9.248942e+01 M0,1.263712e+02 L500,1.263712e+02 M0,1.602529e+02 L500,1.602529e+02 M0,1.941347e+02 L500,1.941347e+02 M0,2.280164e+02 L500,2.280164e+02 M0,2.618982e+02 L500,2.618982e+02 M0,2.957799e+02 L500,2.957799e+02 M0,3.296617e+02 L500,3.296617e+02 \"/></g><g fill=\"none\" font-weight=\"bold\" text-anchor=\"middle\" stroke-linejoin=\"round\" font-size=\"12px\" font-style=\"normal\" font-family=\"sans-serif\" stroke-width=\"2px\" stroke-linecap=\"round\" dominant-baseline=\"hanging\" stroke=\"black\"><rect x=\"70\" y=\"70\" width=\"500\" height=\"340\" vector-effect=\"non-scaling-stroke\"/><g dominant-baseline=\"middle\" fill=\"black\" font-size=\"18px\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"320\" y=\"35\" dominant-baseline=\"middle\">A diagram of sorts 📊 📈</text></g></g></svg></div>"
       ]
      },
      "metadata": {},
@@ -658,12 +694,14 @@
    "source": [
     "### Animated Plots with `UpdateHTML`\n",
     "\n",
-    "Still using Margaid but now we animate a `Sin(x)` plot varying the frequency from 0.0 to 10.0, every 10 milliseconds. This demonstrates `gonbui.UpdateHTML(id, html)`: it allows a transient HTML cell to be updated in the middle of the execution of a cell."
+    "Still using Margaid but now we animate a `Sin(x)` plot varying the frequency from 0.0 to 10.0, every 10 milliseconds. This demonstrates `gonbui.UpdateHTML(id, html)`: it allows a transient HTML cell to be updated in the middle of the execution of a cell.\n",
+    "\n",
+    "> **Note**: This also works with markdown, use `gonbui.UpdateMarkdown(id, markdown)` instead. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 16,
    "id": "293ceefc-c50c-4817-98fe-5f15ee4d0754",
    "metadata": {
     "tags": []
@@ -679,7 +717,7 @@
     {
      "data": {
       "text/html": [
-       "<svg height=\"400\" viewbox=\"0 0 1024 400\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"1024\"><defs><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"circle\" viewBox=\"0 0 10 10 \"><circle stroke=\"black\" cx=\"5\" cy=\"5\" r=\"3\" fill=\"none\"/></marker><marker markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\"><circle r=\"3\" fill=\"black\" stroke=\"none\" cx=\"5\" cy=\"5\"/></marker><marker id=\"square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><rect height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\" y=\"2\" width=\"6\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\"><rect width=\"6\" height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\" y=\"2\"/></marker></defs><g stroke-width=\"3.14px\" stroke-linecap=\"round\" stroke-linejoin=\"round\" transform=\"translate(64 336 )scale(1 -1 )\" fill=\"none\" stroke=\"hsl(198, 47%, 65%)\"><path vector-effect=\"non-scaling-stroke\" d=\"M0.000000e+00,1.360312e+02 C1.508418e+00,1.499049e+02 6.033670e+00,1.968203e+02 9.050505e+00,2.192736e+02 C1.206734e+01,2.417269e+02 1.508418e+01,2.621600e+02 1.810101e+01,2.707510e+02 C2.111785e+01,2.793420e+02 2.413468e+01,2.793693e+02 2.715152e+01,2.708197e+02 C3.016835e+01,2.622702e+02 3.318519e+01,2.418813e+02 3.620202e+01,2.194536e+02 C3.921886e+01,1.970259e+02 4.223569e+01,1.640012e+02 4.525253e+01,1.362537e+02 C4.826936e+01,1.085063e+02 5.128620e+01,7.544786e+01 5.430303e+01,5.296898e+01 C5.731987e+01,3.049010e+01 6.033670e+01,1.001293e+01 6.335354e+01,1.380483e+00 C6.637037e+01,-7.251970e+00 6.938721e+01,-7.333825e+00 7.240404e+01,1.174264e+00 C7.542088e+01,9.682353e+00 7.843771e+01,3.002705e+01 8.145455e+01,5.242902e+01 C8.447138e+01,7.483099e+01 8.748822e+01,1.078388e+02 9.050505e+01,1.355861e+02 C9.352189e+01,1.633334e+02 9.653872e+01,1.964086e+02 9.955556e+01,2.189130e+02 C1.025724e+02,2.414174e+02 1.055892e+02,2.619386e+02 1.086061e+02,2.706125e+02 C1.116229e+02,2.792864e+02 1.146397e+02,2.794228e+02 1.176566e+02,2.709562e+02 C1.206734e+02,2.624896e+02 1.236902e+02,2.421892e+02 1.267071e+02,2.198130e+02 C1.297239e+02,1.974367e+02 1.327407e+02,1.644460e+02 1.357576e+02,1.366989e+02 C1.387744e+02,1.089517e+02 1.417912e+02,7.585985e+01 1.448081e+02,5.332998e+01 C1.478249e+02,3.080011e+01 1.508418e+02,1.023488e+01 1.538586e+02,1.519623e+00 C1.568754e+02,-7.195632e+00 1.598923e+02,-7.386626e+00 1.629091e+02,1.038449e+00 C1.659259e+02,9.463524e+00 1.689428e+02,2.971965e+01 1.719596e+02,5.207007e+01 C1.749764e+02,7.442050e+01 1.779933e+02,1.073941e+02 1.810101e+02,1.351410e+02 C1.840269e+02,1.628879e+02 1.870438e+02,1.959963e+02 1.900606e+02,2.185516e+02 C1.930774e+02,2.411069e+02 1.960943e+02,2.617161e+02 1.991111e+02,2.704727e+02 C2.021279e+02,2.792293e+02 2.051448e+02,2.794749e+02 2.081616e+02,2.710914e+02 C2.111785e+02,2.627078e+02 2.141953e+02,2.424960e+02 2.172121e+02,2.201715e+02 C2.202290e+02,1.978469e+02 2.232458e+02,1.648906e+02 2.262626e+02,1.371440e+02 C2.292795e+02,1.093973e+02 2.322963e+02,7.627244e+01 2.353131e+02,5.369180e+01 C2.383300e+02,3.111115e+01 2.413468e+02,1.045806e+01 2.443636e+02,1.660091e+00 C2.473805e+02,-7.137881e+00 2.503973e+02,-7.438012e+00 2.534141e+02,9.039661e-01 C2.564310e+02,9.245944e+00 2.594478e+02,2.941330e+01 2.624646e+02,5.171196e+01 C2.654815e+02,7.401061e+01 2.684983e+02,1.069497e+02 2.715152e+02,1.346959e+02 C2.745320e+02,1.624421e+02 2.775488e+02,1.955834e+02 2.805657e+02,2.181894e+02 C2.835825e+02,2.407953e+02 2.865993e+02,2.614923e+02 2.896162e+02,2.703316e+02 C2.926330e+02,2.791709e+02 2.956498e+02,2.795256e+02 2.986667e+02,2.712252e+02 C3.016835e+02,2.629248e+02 3.047003e+02,2.428019e+02 3.077172e+02,2.205292e+02 C3.107340e+02,1.982565e+02 3.137508e+02,1.653348e+02 3.167677e+02,1.375890e+02 C3.197845e+02,1.098432e+02 3.228013e+02,7.668562e+01 3.258182e+02,5.405442e+01 C3.288350e+02,3.142323e+01 3.318519e+02,1.068249e+01 3.348687e+02,1.801885e+00 C3.378855e+02,-7.078717e+00 3.409024e+02,-7.487981e+00 3.439192e+02,7.708167e-01 C3.469360e+02,9.029615e+00 3.499529e+02,2.910801e+01 3.529697e+02,5.135467e+01 C3.559865e+02,7.360134e+01 3.590034e+02,1.065055e+02 3.620202e+02,1.342508e+02 C3.650370e+02,1.619961e+02 3.680539e+02,1.951700e+02 3.710707e+02,2.178263e+02 C3.740875e+02,2.404827e+02 3.771044e+02,2.612672e+02 3.801212e+02,2.701891e+02 C3.831380e+02,2.791110e+02 3.861549e+02,2.795748e+02 3.891717e+02,2.713576e+02 C3.921886e+02,2.631405e+02 3.952054e+02,2.431066e+02 3.982222e+02,2.208860e+02 C4.012391e+02,1.986655e+02 4.042559e+02,1.657788e+02 4.072727e+02,1.380341e+02 C4.102896e+02,1.102894e+02 4.133064e+02,7.709938e+01 4.163232e+02,5.441786e+01 C4.193401e+02,3.173635e+01 4.223569e+02,1.090815e+01 4.253737e+02,1.945003e+00 C4.283906e+02,-7.018140e+00 4.314074e+02,-7.536535e+00 4.344242e+02,6.390024e-01 C4.374411e+02,8.814539e+00 4.404579e+02,2.880377e+01 4.434747e+02,5.099823e+01 C4.464916e+02,7.319268e+01 4.495084e+02,1.060617e+02 4.525253e+02,1.338058e+02 C4.555421e+02,1.615498e+02 4.585589e+02,1.947559e+02 4.615758e+02,2.174625e+02 C4.645926e+02,2.401691e+02 4.676094e+02,2.610410e+02 4.706263e+02,2.700453e+02 C4.736431e+02,2.790497e+02 4.766599e+02,2.796227e+02 4.796768e+02,2.714888e+02 C4.826936e+02,2.633549e+02 4.857104e+02,2.434103e+02 4.887273e+02,2.212421e+02 C4.917441e+02,1.990738e+02 4.947609e+02,1.662225e+02 4.977778e+02,1.384792e+02 C5.007946e+02,1.107358e+02 5.038114e+02,7.751373e+01 5.068283e+02,5.478211e+01 C5.098451e+02,3.205049e+01 5.128620e+02,1.113504e+01 5.158788e+02,2.089446e+00 C5.188956e+02,-6.956152e+00 5.219125e+02,-7.583671e+00 5.249293e+02,5.085242e-01 C5.279461e+02,8.600720e+00 5.309630e+02,2.850059e+01 5.339798e+02,5.064262e+01 C5.369966e+02,7.278465e+01 5.400135e+02,1.056182e+02 5.430303e+02,1.333607e+02 C5.460471e+02,1.611033e+02 5.490640e+02,1.943413e+02 5.520808e+02,2.170979e+02 C5.550976e+02,2.398544e+02 5.581145e+02,2.608134e+02 5.611313e+02,2.699002e+02 C5.641481e+02,2.789870e+02 5.671650e+02,2.796691e+02 5.701818e+02,2.716186e+02 C5.731987e+02,2.635681e+02 5.762155e+02,2.437130e+02 5.792323e+02,2.215973e+02 C5.822492e+02,1.994815e+02 5.852660e+02,1.666659e+02 5.882828e+02,1.389242e+02 C5.912997e+02,1.111825e+02 5.943165e+02,7.792865e+01 5.973333e+02,5.514715e+01 C6.003502e+02,3.236566e+01 6.033670e+02,1.136317e+01 6.063838e+02,2.235210e+00 C6.094007e+02,-6.892752e+00 6.124175e+02,-7.629390e+00 6.154343e+02,3.793837e-01 C6.184512e+02,8.388157e+00 6.214680e+02,2.819847e+01 6.244848e+02,5.028785e+01 C6.275017e+02,7.237724e+01 6.305185e+02,1.051749e+02 6.335354e+02,1.329157e+02 C6.365522e+02,1.606565e+02 6.395690e+02,1.939261e+02 6.425859e+02,2.167324e+02 C6.456027e+02,2.395388e+02 6.486195e+02,2.605847e+02 6.516364e+02,2.697538e+02 C6.546532e+02,2.789229e+02 6.576700e+02,2.797141e+02 6.606869e+02,2.717471e+02 C6.637037e+02,2.637800e+02 6.667205e+02,2.440146e+02 6.697374e+02,2.219516e+02 C6.727542e+02,1.998886e+02 6.757710e+02,1.671090e+02 6.787879e+02,1.393692e+02 C6.818047e+02,1.116294e+02 6.848215e+02,7.834414e+01 6.878384e+02,5.551300e+01 C6.908552e+02,3.268185e+01 6.938721e+02,1.159253e+01 6.968889e+02,2.382294e+00 C6.999057e+02,-6.827941e+00 7.029226e+02,-7.673691e+00 7.059394e+02,2.515819e-01 C7.089562e+02,8.176855e+00 7.119731e+02,2.789741e+01 7.149899e+02,4.993393e+01 C7.180067e+02,7.197046e+01 7.210236e+02,1.047320e+02 7.240404e+02,1.324707e+02 C7.270572e+02,1.602094e+02 7.300741e+02,1.935103e+02 7.330909e+02,2.163662e+02 C7.361077e+02,2.392221e+02 7.391246e+02,2.603547e+02 7.421414e+02,2.696061e+02 C7.451582e+02,2.788574e+02 7.481751e+02,2.797577e+02 7.511919e+02,2.718742e+02 C7.542088e+02,2.639907e+02 7.572256e+02,2.443151e+02 7.602424e+02,2.223051e+02 C7.632593e+02,2.002951e+02 7.662761e+02,1.675517e+02 7.692929e+02,1.398141e+02 C7.723098e+02,1.120766e+02 7.753266e+02,7.876021e+01 7.783434e+02,5.587964e+01 C7.813603e+02,3.299906e+01 7.843771e+02,1.182312e+01 7.873939e+02,2.530698e+00 C7.904108e+02,-6.761721e+00 7.934276e+02,-7.716574e+00 7.964444e+02,1.251203e-01 C7.994613e+02,7.966814e+00 8.024781e+02,2.759742e+01 8.054949e+02,4.958086e+01 C8.085118e+02,7.156431e+01 8.115286e+02,1.042894e+02 8.145455e+02,1.320258e+02 C8.175623e+02,1.597622e+02 8.205791e+02,1.930939e+02 8.235960e+02,2.159991e+02 C8.266128e+02,2.389043e+02 8.296296e+02,2.601235e+02 8.326465e+02,2.694570e+02 C8.356633e+02,2.787905e+02 8.386801e+02,2.797999e+02 8.416970e+02,2.720000e+02 C8.447138e+02,2.642001e+02 8.477306e+02,2.446146e+02 8.507475e+02,2.226577e+02 C8.537643e+02,2.007009e+02 8.567811e+02,1.679942e+02 8.597980e+02,1.402591e+02 C8.628148e+02,1.125240e+02 8.658316e+02,7.917684e+01 8.688485e+02,5.624706e+01 C8.718653e+02,3.331729e+01 8.748822e+02,1.205493e+01 8.778990e+02,2.680419e+00 C8.809158e+02,-6.694092e+00 8.839327e+02,-7.758038e+00 8.869495e+02,0.000000e+00 C8.899663e+02,7.758038e+00 8.944916e+02,4.102387e+01 8.960000e+02,4.922865e+01 \"/></g><g fill=\"none\" stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect vector-effect=\"non-scaling-stroke\" x=\"64\" y=\"64\" width=\"896\" height=\"272\"/><g fill=\"black\" font-family=\"sans-serif\" font-weight=\"bold\" text-anchor=\"middle\" font-size=\"18px\" font-style=\"normal\" dominant-baseline=\"middle\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"512\" y=\"32\" dominant-baseline=\"middle\">Animated Sine</text></g></g></svg>"
+       "<svg height=\"400\" viewbox=\"0 0 1024 400\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"1024\"><defs><marker id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><circle cy=\"5\" r=\"3\" fill=\"none\" stroke=\"black\" cx=\"5\"/></marker><marker markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\"><circle cx=\"5\" cy=\"5\" r=\"3\" fill=\"black\" stroke=\"none\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"square\" viewBox=\"0 0 10 10 \"><rect height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\" y=\"2\" width=\"6\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\" viewBox=\"0 0 10 10 \"><rect y=\"2\" width=\"6\" height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\"/></marker></defs><g stroke=\"hsl(198, 47%, 65%)\" stroke-width=\"3.14px\" stroke-linecap=\"round\" stroke-linejoin=\"round\" transform=\"translate(64 336 )scale(1 -1 )\" fill=\"none\"><path vector-effect=\"non-scaling-stroke\" d=\"M0.000000e+00,1.360312e+02 C1.508418e+00,1.499049e+02 6.033670e+00,1.968203e+02 9.050505e+00,2.192736e+02 C1.206734e+01,2.417269e+02 1.508418e+01,2.621600e+02 1.810101e+01,2.707510e+02 C2.111785e+01,2.793420e+02 2.413468e+01,2.793693e+02 2.715152e+01,2.708197e+02 C3.016835e+01,2.622702e+02 3.318519e+01,2.418813e+02 3.620202e+01,2.194536e+02 C3.921886e+01,1.970259e+02 4.223569e+01,1.640012e+02 4.525253e+01,1.362537e+02 C4.826936e+01,1.085063e+02 5.128620e+01,7.544786e+01 5.430303e+01,5.296898e+01 C5.731987e+01,3.049010e+01 6.033670e+01,1.001293e+01 6.335354e+01,1.380483e+00 C6.637037e+01,-7.251970e+00 6.938721e+01,-7.333825e+00 7.240404e+01,1.174264e+00 C7.542088e+01,9.682353e+00 7.843771e+01,3.002705e+01 8.145455e+01,5.242902e+01 C8.447138e+01,7.483099e+01 8.748822e+01,1.078388e+02 9.050505e+01,1.355861e+02 C9.352189e+01,1.633334e+02 9.653872e+01,1.964086e+02 9.955556e+01,2.189130e+02 C1.025724e+02,2.414174e+02 1.055892e+02,2.619386e+02 1.086061e+02,2.706125e+02 C1.116229e+02,2.792864e+02 1.146397e+02,2.794228e+02 1.176566e+02,2.709562e+02 C1.206734e+02,2.624896e+02 1.236902e+02,2.421892e+02 1.267071e+02,2.198130e+02 C1.297239e+02,1.974367e+02 1.327407e+02,1.644460e+02 1.357576e+02,1.366989e+02 C1.387744e+02,1.089517e+02 1.417912e+02,7.585985e+01 1.448081e+02,5.332998e+01 C1.478249e+02,3.080011e+01 1.508418e+02,1.023488e+01 1.538586e+02,1.519623e+00 C1.568754e+02,-7.195632e+00 1.598923e+02,-7.386626e+00 1.629091e+02,1.038449e+00 C1.659259e+02,9.463524e+00 1.689428e+02,2.971965e+01 1.719596e+02,5.207007e+01 C1.749764e+02,7.442050e+01 1.779933e+02,1.073941e+02 1.810101e+02,1.351410e+02 C1.840269e+02,1.628879e+02 1.870438e+02,1.959963e+02 1.900606e+02,2.185516e+02 C1.930774e+02,2.411069e+02 1.960943e+02,2.617161e+02 1.991111e+02,2.704727e+02 C2.021279e+02,2.792293e+02 2.051448e+02,2.794749e+02 2.081616e+02,2.710914e+02 C2.111785e+02,2.627078e+02 2.141953e+02,2.424960e+02 2.172121e+02,2.201715e+02 C2.202290e+02,1.978469e+02 2.232458e+02,1.648906e+02 2.262626e+02,1.371440e+02 C2.292795e+02,1.093973e+02 2.322963e+02,7.627244e+01 2.353131e+02,5.369180e+01 C2.383300e+02,3.111115e+01 2.413468e+02,1.045806e+01 2.443636e+02,1.660091e+00 C2.473805e+02,-7.137881e+00 2.503973e+02,-7.438012e+00 2.534141e+02,9.039661e-01 C2.564310e+02,9.245944e+00 2.594478e+02,2.941330e+01 2.624646e+02,5.171196e+01 C2.654815e+02,7.401061e+01 2.684983e+02,1.069497e+02 2.715152e+02,1.346959e+02 C2.745320e+02,1.624421e+02 2.775488e+02,1.955834e+02 2.805657e+02,2.181894e+02 C2.835825e+02,2.407953e+02 2.865993e+02,2.614923e+02 2.896162e+02,2.703316e+02 C2.926330e+02,2.791709e+02 2.956498e+02,2.795256e+02 2.986667e+02,2.712252e+02 C3.016835e+02,2.629248e+02 3.047003e+02,2.428019e+02 3.077172e+02,2.205292e+02 C3.107340e+02,1.982565e+02 3.137508e+02,1.653348e+02 3.167677e+02,1.375890e+02 C3.197845e+02,1.098432e+02 3.228013e+02,7.668562e+01 3.258182e+02,5.405442e+01 C3.288350e+02,3.142323e+01 3.318519e+02,1.068249e+01 3.348687e+02,1.801885e+00 C3.378855e+02,-7.078717e+00 3.409024e+02,-7.487981e+00 3.439192e+02,7.708167e-01 C3.469360e+02,9.029615e+00 3.499529e+02,2.910801e+01 3.529697e+02,5.135467e+01 C3.559865e+02,7.360134e+01 3.590034e+02,1.065055e+02 3.620202e+02,1.342508e+02 C3.650370e+02,1.619961e+02 3.680539e+02,1.951700e+02 3.710707e+02,2.178263e+02 C3.740875e+02,2.404827e+02 3.771044e+02,2.612672e+02 3.801212e+02,2.701891e+02 C3.831380e+02,2.791110e+02 3.861549e+02,2.795748e+02 3.891717e+02,2.713576e+02 C3.921886e+02,2.631405e+02 3.952054e+02,2.431066e+02 3.982222e+02,2.208860e+02 C4.012391e+02,1.986655e+02 4.042559e+02,1.657788e+02 4.072727e+02,1.380341e+02 C4.102896e+02,1.102894e+02 4.133064e+02,7.709938e+01 4.163232e+02,5.441786e+01 C4.193401e+02,3.173635e+01 4.223569e+02,1.090815e+01 4.253737e+02,1.945003e+00 C4.283906e+02,-7.018140e+00 4.314074e+02,-7.536535e+00 4.344242e+02,6.390024e-01 C4.374411e+02,8.814539e+00 4.404579e+02,2.880377e+01 4.434747e+02,5.099823e+01 C4.464916e+02,7.319268e+01 4.495084e+02,1.060617e+02 4.525253e+02,1.338058e+02 C4.555421e+02,1.615498e+02 4.585589e+02,1.947559e+02 4.615758e+02,2.174625e+02 C4.645926e+02,2.401691e+02 4.676094e+02,2.610410e+02 4.706263e+02,2.700453e+02 C4.736431e+02,2.790497e+02 4.766599e+02,2.796227e+02 4.796768e+02,2.714888e+02 C4.826936e+02,2.633549e+02 4.857104e+02,2.434103e+02 4.887273e+02,2.212421e+02 C4.917441e+02,1.990738e+02 4.947609e+02,1.662225e+02 4.977778e+02,1.384792e+02 C5.007946e+02,1.107358e+02 5.038114e+02,7.751373e+01 5.068283e+02,5.478211e+01 C5.098451e+02,3.205049e+01 5.128620e+02,1.113504e+01 5.158788e+02,2.089446e+00 C5.188956e+02,-6.956152e+00 5.219125e+02,-7.583671e+00 5.249293e+02,5.085242e-01 C5.279461e+02,8.600720e+00 5.309630e+02,2.850059e+01 5.339798e+02,5.064262e+01 C5.369966e+02,7.278465e+01 5.400135e+02,1.056182e+02 5.430303e+02,1.333607e+02 C5.460471e+02,1.611033e+02 5.490640e+02,1.943413e+02 5.520808e+02,2.170979e+02 C5.550976e+02,2.398544e+02 5.581145e+02,2.608134e+02 5.611313e+02,2.699002e+02 C5.641481e+02,2.789870e+02 5.671650e+02,2.796691e+02 5.701818e+02,2.716186e+02 C5.731987e+02,2.635681e+02 5.762155e+02,2.437130e+02 5.792323e+02,2.215973e+02 C5.822492e+02,1.994815e+02 5.852660e+02,1.666659e+02 5.882828e+02,1.389242e+02 C5.912997e+02,1.111825e+02 5.943165e+02,7.792865e+01 5.973333e+02,5.514715e+01 C6.003502e+02,3.236566e+01 6.033670e+02,1.136317e+01 6.063838e+02,2.235210e+00 C6.094007e+02,-6.892752e+00 6.124175e+02,-7.629390e+00 6.154343e+02,3.793837e-01 C6.184512e+02,8.388157e+00 6.214680e+02,2.819847e+01 6.244848e+02,5.028785e+01 C6.275017e+02,7.237724e+01 6.305185e+02,1.051749e+02 6.335354e+02,1.329157e+02 C6.365522e+02,1.606565e+02 6.395690e+02,1.939261e+02 6.425859e+02,2.167324e+02 C6.456027e+02,2.395388e+02 6.486195e+02,2.605847e+02 6.516364e+02,2.697538e+02 C6.546532e+02,2.789229e+02 6.576700e+02,2.797141e+02 6.606869e+02,2.717471e+02 C6.637037e+02,2.637800e+02 6.667205e+02,2.440146e+02 6.697374e+02,2.219516e+02 C6.727542e+02,1.998886e+02 6.757710e+02,1.671090e+02 6.787879e+02,1.393692e+02 C6.818047e+02,1.116294e+02 6.848215e+02,7.834414e+01 6.878384e+02,5.551300e+01 C6.908552e+02,3.268185e+01 6.938721e+02,1.159253e+01 6.968889e+02,2.382294e+00 C6.999057e+02,-6.827941e+00 7.029226e+02,-7.673691e+00 7.059394e+02,2.515819e-01 C7.089562e+02,8.176855e+00 7.119731e+02,2.789741e+01 7.149899e+02,4.993393e+01 C7.180067e+02,7.197046e+01 7.210236e+02,1.047320e+02 7.240404e+02,1.324707e+02 C7.270572e+02,1.602094e+02 7.300741e+02,1.935103e+02 7.330909e+02,2.163662e+02 C7.361077e+02,2.392221e+02 7.391246e+02,2.603547e+02 7.421414e+02,2.696061e+02 C7.451582e+02,2.788574e+02 7.481751e+02,2.797577e+02 7.511919e+02,2.718742e+02 C7.542088e+02,2.639907e+02 7.572256e+02,2.443151e+02 7.602424e+02,2.223051e+02 C7.632593e+02,2.002951e+02 7.662761e+02,1.675517e+02 7.692929e+02,1.398141e+02 C7.723098e+02,1.120766e+02 7.753266e+02,7.876021e+01 7.783434e+02,5.587964e+01 C7.813603e+02,3.299906e+01 7.843771e+02,1.182312e+01 7.873939e+02,2.530698e+00 C7.904108e+02,-6.761721e+00 7.934276e+02,-7.716574e+00 7.964444e+02,1.251203e-01 C7.994613e+02,7.966814e+00 8.024781e+02,2.759742e+01 8.054949e+02,4.958086e+01 C8.085118e+02,7.156431e+01 8.115286e+02,1.042894e+02 8.145455e+02,1.320258e+02 C8.175623e+02,1.597622e+02 8.205791e+02,1.930939e+02 8.235960e+02,2.159991e+02 C8.266128e+02,2.389043e+02 8.296296e+02,2.601235e+02 8.326465e+02,2.694570e+02 C8.356633e+02,2.787905e+02 8.386801e+02,2.797999e+02 8.416970e+02,2.720000e+02 C8.447138e+02,2.642001e+02 8.477306e+02,2.446146e+02 8.507475e+02,2.226577e+02 C8.537643e+02,2.007009e+02 8.567811e+02,1.679942e+02 8.597980e+02,1.402591e+02 C8.628148e+02,1.125240e+02 8.658316e+02,7.917684e+01 8.688485e+02,5.624706e+01 C8.718653e+02,3.331729e+01 8.748822e+02,1.205493e+01 8.778990e+02,2.680419e+00 C8.809158e+02,-6.694092e+00 8.839327e+02,-7.758038e+00 8.869495e+02,0.000000e+00 C8.899663e+02,7.758038e+00 8.944916e+02,4.102387e+01 8.960000e+02,4.922865e+01 \"/></g><g stroke-width=\"2px\" stroke-linecap=\"round\" stroke-linejoin=\"round\" fill=\"none\" stroke=\"black\"><rect x=\"64\" y=\"64\" width=\"896\" height=\"272\" vector-effect=\"non-scaling-stroke\"/><g font-style=\"normal\" font-weight=\"bold\" fill=\"black\" font-family=\"sans-serif\" text-anchor=\"middle\" dominant-baseline=\"middle\" font-size=\"18px\"><text vector-effect=\"non-scaling-stroke\" x=\"512\" y=\"32\" dominant-baseline=\"middle\" stroke=\"none\">Animated Sine</text></g></g></svg>"
       ]
      },
      "metadata": {},
@@ -745,7 +783,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 17,
    "id": "58248364-f1b3-4e56-adc7-7034a1f6c56d",
    "metadata": {},
    "outputs": [
@@ -823,7 +861,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 18,
    "id": "b5e2269c-3f8c-4f61-9b73-317d0c71498c",
    "metadata": {},
    "outputs": [
@@ -1054,7 +1092,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 19,
    "id": "03452fc9-f43c-4fb1-b1ce-50df961a214d",
    "metadata": {},
    "outputs": [
@@ -1077,7 +1115,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 20,
    "id": "13a230fd-1179-4ec3-b24c-4f89e0913920",
    "metadata": {},
    "outputs": [
@@ -1109,7 +1147,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 21,
    "id": "0b8683aa-0bf0-4058-8992-1c5b9e2c2b0c",
    "metadata": {},
    "outputs": [
@@ -1144,7 +1182,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 22,
    "id": "4e2e9992-3a74-4825-87d8-773bdc30b05f",
    "metadata": {
     "tags": []
@@ -1180,7 +1218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 23,
    "id": "27c7aaad-b0d3-46f0-b1f6-dc66722fe5bd",
    "metadata": {
     "tags": []
@@ -1219,7 +1257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 24,
    "id": "724e33f4-c5fa-4fbe-9d90-e411369a74f3",
    "metadata": {},
    "outputs": [
@@ -1229,10 +1267,10 @@
      "text": [
       "go version go1.20.5 linux/amd64\n",
       "/home/janpf/Projects/gonb/examples\n",
-      "total 364\n",
+      "total 368\n",
       "-rw-r--r-- 1 janpf janpf 158378 Mar  8 07:18 experimental.ipynb\n",
       "-rwxr-xr-x 1 janpf janpf  87160 May 22 11:29 google_colab_demo.ipynb\n",
-      "-rw-r--r-- 1 janpf janpf 122266 Aug  8 09:16 tutorial.ipynb\n"
+      "-rw-r--r-- 1 janpf janpf 123179 Aug  8 10:41 tutorial.ipynb\n"
      ]
     }
    ],
@@ -1256,7 +1294,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 25,
    "id": "be207993-219d-4a7f-a130-5111971fb867",
    "metadata": {},
    "outputs": [
@@ -1264,14 +1302,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/tmp/gonb_f47c498f\n",
+      "/tmp/gonb_728b1b08\n",
       "total 8948\n",
-      "-rw-r--r-- 1 janpf janpf    1202 Aug  8 09:16 go.mod\n",
-      "-rwxr-xr-x 1 janpf janpf 9135352 Aug  8 09:16 gonb_f47c498f\n",
-      "prw------- 1 janpf janpf       0 Aug  8 09:16 gonb_pipe_2553551255\n",
-      "srwxr-xr-x 1 janpf janpf       0 Aug  8 09:15 gopls_socket\n",
-      "-rw-r--r-- 1 janpf janpf   10229 Aug  8 09:16 go.sum\n",
-      "-rw-r--r-- 1 janpf janpf    4708 Aug  8 09:16 main.go\n"
+      "-rw-r--r-- 1 janpf janpf    1267 Aug  8 10:41 go.mod\n",
+      "-rwxr-xr-x 1 janpf janpf 9135352 Aug  8 10:41 gonb_728b1b08\n",
+      "prw------- 1 janpf janpf       0 Aug  8 10:41 gonb_pipe_3804130167\n",
+      "srwxr-xr-x 1 janpf janpf       0 Aug  8 10:40 gopls_socket\n",
+      "-rw-r--r-- 1 janpf janpf   10058 Aug  8 10:41 go.sum\n",
+      "-rw-r--r-- 1 janpf janpf    4708 Aug  8 10:41 main.go\n"
      ]
     }
    ],
@@ -1291,7 +1329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 26,
    "id": "8688859a-ec3b-4e54-99b4-abbd8542091d",
    "metadata": {},
    "outputs": [
@@ -1365,7 +1403,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 27,
    "id": "3391f12e-131b-45b8-b270-6ba06abaac8c",
    "metadata": {
     "tags": []
@@ -1375,9 +1413,11 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "module gonb_f47c498f\n",
+      "module gonb_728b1b08\n",
       "\n",
       "go 1.20\n",
+      "\n",
+      "replace github.com/janpfeifer/gonb => /home/janpf/Projects/gonb\n",
       "\n",
       "require (\n",
       "\tgithub.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b\n",
@@ -1406,9 +1446,7 @@
       "\tgolang.org/x/term v0.6.0 // indirect\n",
       "\tgolang.org/x/text v0.9.0 // indirect\n",
       "\tgopkg.in/yaml.v2 v2.3.0 // indirect\n",
-      ")\n",
-      "\n",
-      "replace github.com/janpfeifer/gonb => /home/janpf/Projects/gonb\n"
+      ")\n"
      ]
     }
    ],
@@ -1431,7 +1469,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 28,
    "id": "45cf4a12-4b93-480f-bd83-2d375e7a475d",
    "metadata": {
     "tags": []
@@ -1477,7 +1515,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 29,
    "id": "f6d836c1-3dfd-41a0-b097-b157f33289a8",
    "metadata": {
     "tags": []
@@ -1529,120 +1567,146 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 30,
    "id": "ba9172b8-ede5-44cd-baa1-a58a1d668a98",
    "metadata": {
     "tags": []
    },
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GoNB is a Go kernel that compiles and executed on-the-fly Go code. \n",
-      "\n",
-      "When executing a cell, *GoNB* will save the cell contents (except non-Go commands see\n",
-      "below) into a \"main.go\" file, compile and execute it.\n",
-      "\n",
-      "It also saves any global declarations (imports, functions, types, variables, constants)\n",
-      "and reuse them at the next cell execution -- so you can define a function in one\n",
-      "cell, and reuse in the next one. Just the \"func main()\" is not reused.\n",
-      "\n",
-      "A \"hello world\" example would look like:\n",
-      "\n",
-      "\tfunc main() {\n",
-      "\t\tfmt.Printf(\"Hello world!\\n\");\n",
-      "\t}\n",
-      "\n",
-      "But to avoid having to type \"func main()\" all the time, you can use \"%%\" and everything\n",
-      "after is wrapped inside a \"func main() { ... }\". So our revised \"hello world\" looks like:\n",
-      "\n",
-      "\t%%\n",
-      "\tfmt.Printf(\"Hello world!\\n\")\n",
-      "\n",
-      "Init Functions -- \"func init()\":\n",
-      "\n",
-      "  Since there is always only one definition per function name, it's not possible for\n",
-      "  each cell to have it's own init() function. Instead GoNB converts any function named \n",
-      "  \"init_<my_stuff>()\" to \"init()\" before compiling and executing. This way each cell can\n",
-      "  create its own \"init_...()\" and have it called at every cell execution.\n",
-      "\n",
-      "Special non-Go commands: \n",
-      "\n",
-      "- \"%%\" or \"%main\": Marks the lines as follows to be wrapped in a \"func main() {...}\" during \n",
-      "  execution. A shortcut to quickly execute code. It also automatically includes \"flag.Parse()\"\n",
-      "  as the very first statement. Anything \"%%\" or \"%main\" are taken as arguments\n",
-      "  to be passed to the program -- it resets previous values given by \"%args\".\n",
-      "- \"%args\": Sets arguments to be passed when executing the Go code. This allows one to\n",
-      "  use flags as a normal program. Notice that if a value after \"%%\" or \"%main\" is given, it will\n",
-      "  overwrite the values here.\n",
-      "- \"%autoget\" and \"%noautoget\": Default is \"%autoget\", which automatically does \"go get\" for\n",
-      "  packages not yet available.\n",
-      "- \"%cd [<directory>]\": Change current directory of the Go kernel, and the directory from where\n",
-      "  the cells are executed. If no directory is given it reports the current directory.\n",
-      "- \"%env VAR value\": Sets the environment variable VAR to the given value. These variables\n",
-      "  will be available both for Go code as well as for shell scripts.\n",
-      "- \"%with_inputs\": will prompt for inputs for the next shell command. Use this if\n",
-      "  the next shell command (\"!\") you execute reads the stdin. Jupyter will require\n",
-      "  you to enter one last value after the shell script executes.\n",
-      "- \"%with_password\": will prompt for a password passed to the next shell command.\n",
-      "  Do this is if your next shell command requires a password.\n",
-      "\n",
-      "Managing Memorized Definitions:\n",
-      "\n",
-      "- \"%list\" (or \"%ls\"): Lists all memorized definitions (imports, constants, types, variables and\n",
-      "  functions) that are carried from one cell to another.\n",
-      "- \"%remove <definitions>\" (or \"%rm <definitions>\"): Removes (forgets) given definition(s). Use as key the\n",
-      "  value(s) listed with \"%ls\".\n",
-      "- \"%reset [go.mod]\" clears all memorized definitions (imports, constants, types, functions, etc.)\n",
-      "  as well as re-initializes the go.mod file. If the optional \"go.mod\" parameter is given, it \n",
-      "  will re-initialize only the go.mod file -- useful when testing different set up of versions \n",
-      "  of libraries.\n",
-      "\n",
-      "Executing shell commands:\n",
-      "\n",
-      "- \"!<shell_cmd>\": executes the given command on a new shell. It makes it easy to run\n",
-      "  commands on the kernels box, for instance to install requirements, or quickly\n",
-      "  check contents of directories or files. Lines ending in \"\\\" are continued on\n",
-      "  the next line -- so multi-line commands can be entered. But each command is\n",
-      "  executed in its own shell, that is, variables and state is not carried over.\n",
-      "- \"!*<shell_cmd>\": same as \"!<shell_cmd>\" except it first changes directory to\n",
-      "  the temporary directory used to compile the go code -- the latest execution\n",
-      "  is always saved in the file \"main.go\". It's also where the \"go.mod\" file for\n",
-      "  the notebook is created and maintained. Useful for manipulating \"go.mod\",\n",
-      "  for instance to get a package from some specific version, something \n",
-      "  like \"!*go get github.com/my/package@v3\".\n",
-      "\n",
-      "Tracking of Go files being developed:\n",
-      "\n",
-      "- \"%track [file_or_directory]\": add file or directory to list of tracked files,\n",
-      "  which are monitored by GoNB (and 'gopls') for auto-complete or contextual help.\n",
-      "  If no file is given, it lists the currently tracked files.\n",
-      "- \"%untrack [file_or_directory][...]\": remove file or directory from list of tracked files.\n",
-      "  If suffixed with \"...\" it will remove all files prefixed with the string given (without the\n",
-      "  \"...\"). If no file is given, it lists the currently tracked files. \n",
-      "\n",
-      "Environment Variables:\n",
-      "\n",
-      "For convenience, GoNB defines the following environment variables -- available for the shell \n",
-      "scripts (\"! and \"!*\") and for the Go cells:\n",
-      "\n",
-      "- \"GONB_DIR\": the directory where commands are executed from. This can be changed with \"%cd\".\n",
-      "- \"GONB_TMP_DIR\": the directory where the temporary Go code, with the cell code, is stored \n",
-      "  and compiled. This is the directory where \"!*\" scripts are executed. It only changes when a kernel\n",
-      "  is restarted, and a new temporary directory is created.\n",
-      "- \"GONB_PIPE\": is the _named pipe_ directory used to communicate rich content (HTML, images)\n",
-      "  to the kernel. Only available for _Go_ cells, and a new one is created at every execution.\n",
-      "  This is used by the \"gonbui\"\" functions described above, and doesn't need to be accessed directly.\n",
-      "\n",
-      "Other:\n",
-      "\n",
-      "- \"%goworkfix\": work around 'go get' inability to handle 'go.work' files. If you are\n",
-      "  using 'go.work' file to point to locally modified modules, consider using this. It creates\n",
-      "  'go mod edit --replace' rules to point to the modules pointed to the 'use' rules in 'go.work'\n",
-      "  file. It overwrites/updates 'replace' rules for those modules, if they already exist. See tutorial\n",
-      "  for an example.\n"
-     ]
+     "data": {
+      "text/markdown": [
+       "## GoNB Help Page\n",
+       "\n",
+       "**GoNB** is a Go kernel that compiles and executes on-the-fly Go code.\n",
+       "\n",
+       "When executing a cell, **GoNB** will save the cell contents (except non-Go commands see\n",
+       "below) into a `main.go` file, compile and execute it.\n",
+       "\n",
+       "It also saves any global declarations (imports, functions, types, variables, constants)\n",
+       "and reuse them at the next cell execution -- so you can define a function in one\n",
+       "cell, and reuse in the next one. Just the `func main()` is not reused.\n",
+       "\n",
+       "A `hello world` example would look like:\n",
+       "\n",
+       "```go\n",
+       "func main() {\n",
+       "    fmt.Printf(`Hello world!\\n`);\n",
+       "}\n",
+       "\n",
+       "```\n",
+       "\n",
+       "But to avoid having to type `func main()` all the time, you can use `%%` and everything\n",
+       "after is wrapped inside a `func main() { ... }`. \n",
+       "So our revised `hello world` looks like:\n",
+       "\n",
+       "```go\n",
+       "%%\n",
+       "fmt.Printf(`Hello world!\\n`)\n",
+       "\n",
+       "```\n",
+       "\n",
+       "### Init Functions -- `func init()`\n",
+       "\n",
+       "Since there is always only one definition per function name, it's not possible for\n",
+       "each cell to have its own init() function. \n",
+       "Instead, **GoNB** converts any function named `init_something()` to `init()` before \n",
+       "compiling and executing. \n",
+       "This way each cell can create its own `init_...()` and have it called at every cell execution.\n",
+       "\n",
+       "### Special non-Go Commands\n",
+       "\n",
+       "- `%%` or `%main`: Marks the lines as follows to be wrapped in a `func main() {...}` during\n",
+       "  execution. A shortcut to quickly execute code. It also automatically includes `flag.Parse()`\n",
+       "  as the very first statement. Anything `%%` or `%main` are taken as arguments\n",
+       "  to be passed to the program -- it resets previous values given by `%args`.\n",
+       "- `%args`: Sets arguments to be passed when executing the Go code. This allows one to\n",
+       "  use flags as a normal program. Notice that if a value after `%%` or `%main` is given, it will\n",
+       "  overwrite the values here.\n",
+       "- `%autoget` and `%noautoget`: Default is `%autoget`, which automatically does `go get` for\n",
+       "  packages not yet available.\n",
+       "- `%cd [<directory>]`: Change current directory of the Go kernel, and the directory from where\n",
+       "  the cells are executed. If no directory is given it reports the current directory.\n",
+       "- `%env VAR value`: Sets the environment variable VAR to the given value. These variables\n",
+       "  will be available both for Go code as well as for shell scripts.\n",
+       "- `%with_inputs`: will prompt for inputs for the next shell command. Use this if\n",
+       "  the next shell command (`!`) you execute reads the stdin. Jupyter will require\n",
+       "  you to enter one last value after the shell script executes.\n",
+       "- `%with_password`: will prompt for a password passed to the next shell command.\n",
+       "  Do this is if your next shell command requires a password.\n",
+       "\n",
+       "### Managing Memorized Definitions\n",
+       "\n",
+       "- `%list` (or `%ls`): Lists all memorized definitions (imports, constants, types, variables and\n",
+       "  functions) that are carried from one cell to another.\n",
+       "- `%remove <definitions>` (or `%rm <definitions>`): Removes (forgets) given definition(s). Use as key the\n",
+       "  value(s) listed with `%ls`.\n",
+       "- `%reset [go.mod]` clears all memorized definitions (imports, constants, types, functions, etc.)\n",
+       "  as well as re-initializes the `go.mod` file. \n",
+       "  If the optional `go.mod` parameter is given, it will re-initialize only the `go.mod` file -- \n",
+       "  useful when testing different set up of versions of libraries.\n",
+       "\n",
+       "### Executing Shell Commands\n",
+       "\n",
+       "- `!<shell_cmd>`: executes the given command on a new shell. It makes it easy to run\n",
+       "  commands on the kernels box, for instance to install requirements, or quickly\n",
+       "  check contents of directories or files. Lines ending in `\\` are continued on\n",
+       "  the next line -- so multi-line commands can be entered. But each command is\n",
+       "  executed in its own shell, that is, variables and state is not carried over.\n",
+       "- `!*<shell_cmd>`: same as `!<shell_cmd>` except it first changes directory to\n",
+       "  the temporary directory used to compile the go code -- the latest execution\n",
+       "  is always saved in the file `main.go`. It's also where the `go.mod` file for\n",
+       "  the notebook is created and maintained. Useful for manipulating `go.mod`,\n",
+       "  for instance to get a package from some specific version, something\n",
+       "  like `!*go get github.com/my/package@v3`.\n",
+       "\n",
+       "### Tracking of Go Files In Development:\n",
+       "\n",
+       "A convenient way to develop programs or libraries in **GoNB** is to use replace\n",
+       "rules in **GoNB**'s `go.mod` to your program or library being developed and test\n",
+       "your program from **GoNB** -- see the \n",
+       "[Tutorial]((https://github.com/janpfeifer/gonb/blob/main/examples/tutorial.ipynb))'s\n",
+       "section \"Developing Go libraries with a notebook\" for different ways of achieving this.\n",
+       "\n",
+       "To manipulate the list of files tracked for changes:\n",
+       "\n",
+       "- `%track [file_or_directory]`: add file or directory to list of tracked files,\n",
+       "  which are monitored by **GoNB** (and 'gopls') for auto-complete or contextual help.\n",
+       "  If no file is given, it lists the currently tracked files.\n",
+       "- `%untrack [file_or_directory][...]`: remove file or directory from list of tracked files.\n",
+       "  If suffixed with `...` it will remove all files prefixed with the string given (without the\n",
+       "  `...`). If no file is given, it lists the currently tracked files.\n",
+       "\n",
+       "### Environment Variables\n",
+       "\n",
+       "For convenience, **GoNB** defines the following environment variables -- available for the shell\n",
+       "scripts (`!` and `!*`) and for the Go cells:\n",
+       "\n",
+       "- `GONB_DIR`: the directory where commands are executed from. This can be changed with `%cd`.\n",
+       "- `GONB_TMP_DIR`: the directory where the temporary Go code, with the cell code, is stored\n",
+       "  and compiled. This is the directory where `!*` scripts are executed. It only changes when a kernel\n",
+       "  is restarted, and a new temporary directory is created.\n",
+       "- `GONB_PIPE`: is the _named pipe_ directory used to communicate rich content (HTML, images)\n",
+       "  to the kernel. Only available for _Go_ cells, and a new one is created at every execution.\n",
+       "  This is used by the `**GoNB**ui`` functions described above, and doesn't need to be accessed directly.\n",
+       "\n",
+       "### Other\n",
+       "\n",
+       "- `%goworkfix`: work around 'go get' inability to handle 'go.work' files. If you are\n",
+       "  using 'go.work' file to point to locally modified modules, consider using this. It creates\n",
+       "  'go mod edit --replace' rules to point to the modules pointed to the 'use' rules in 'go.work'\n",
+       "  file. It overwrites/updates 'replace' rules for those modules, if they already exist. See tutorial\n",
+       "  for an example.\n",
+       "\n",
+       "### Links\n",
+       "\n",
+       "- [github.com/janpfeifer/gonb](https://github.com/janpfeifer/gonb) - GitHub page.\n",
+       "- [Tutorial](https://github.com/janpfeifer/gonb/blob/main/examples/tutorial.ipynb).\n",
+       "- [go.dev](https://pkg.go.dev/github.com/janpfeifer/gonb) package reference."
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
     }
    ],
    "source": [

--- a/examples/tutorial.ipynb
+++ b/examples/tutorial.ipynb
@@ -207,9 +207,8 @@
      "output_type": "stream",
      "text": [
       "\t...VeryExpensive() call...\n",
-      "\t...VeryExpensive() call...\n",
-      "NonCachedValue=334\n",
-      "   CachedValue=751\n"
+      "NonCachedValue=792\n",
+      "   CachedValue=319\n"
      ]
     }
    ],
@@ -240,7 +239,10 @@
    "id": "5a5470b4-43ea-47ae-a111-63ab77376bd0",
    "metadata": {},
    "source": [
-    "The `cache` package has many more features, check out [its documentation](https://pkg.go.dev/github.com/janpfeifer/gonb/cache)."
+    "The `cache` package has many more features, check out [its documentation](https://pkg.go.dev/github.com/janpfeifer/gonb/cache).\n",
+    "\n",
+    "Now, we don't want to have `NonCachedValue` execute `VeryExpensive` at every cell, so let's remove its definition.\n",
+    "See how to manage memorized definitions using `%help`, in the \"Managing Memorized Definitions\" section, it's displayed at the end of the tutorial."
    ]
   },
   {
@@ -250,10 +252,18 @@
    "metadata": {
     "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". removed var NonCachedValue\n",
+      ". removed var CachedValue\n"
+     ]
+    }
+   ],
    "source": [
-    "// Let's reset NonCachedValue so that it is not called again in the following cells.\n",
-    "var NonCachedValue = 0"
+    "%rm NonCachedValue CachedValue"
    ]
   },
   {
@@ -282,7 +292,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      " 100% |████████████████████████████████████████| (25 steps/s) [3s:0s]:0s]\n",
+      " 100% |████████████████████████████████████████| (25 steps/s) [3s:0s]0s]\n",
       "Done\n"
      ]
     }
@@ -361,7 +371,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "lastRenderTime=1.633473\n"
+      "lastRenderTime=1.979382\n"
      ]
     },
     {
@@ -586,7 +596,7 @@
     {
      "data": {
       "text/html": [
-       "<div><svg xmlns=\"http://www.w3.org/2000/svg\" width=\"640\" height=\"480\" viewbox=\"0 0 640 480\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\"><defs><marker id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><circle cx=\"5\" cy=\"5\" r=\"3\" fill=\"none\" stroke=\"black\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\"><circle cy=\"5\" r=\"3\" fill=\"black\" stroke=\"none\" cx=\"5\"/></marker><marker viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"square\"><rect width=\"6\" height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\" y=\"2\"/></marker><marker markerHeight=\"2%\" id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\"><rect width=\"6\" height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\" y=\"2\"/></marker></defs><g marker-mid=\"url(#square)\" stroke=\"hsl(90, 47%, 65%)\" marker-start=\"url(#square)\" fill=\"none\" marker-end=\"url(#square)\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-linecap=\"round\" stroke-width=\"1px\" stroke-linejoin=\"round\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,6.800000e+00 L6.333333e+01,4.306667e+01 L1.166667e+02,7.933333e+01 L170,1.156000e+02 L2.233333e+02,1.518667e+02 L2.766667e+02,1.881333e+02 L330,2.244000e+02 L3.833333e+02,2.606667e+02 L4.366667e+02,2.969333e+02 L490,3.332000e+02 \"/></g><g fill=\"none\" stroke-width=\"3.14px\" stroke-linejoin=\"round\" stroke=\"hsl(301, 88%, 65%)\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,6.800000e+00 C1.888889e+01,6.875434e+00 4.555556e+01,7.018758e+00 6.333333e+01,7.252602e+00 C8.111111e+01,7.486446e+00 9.888889e+01,7.711993e+00 1.166667e+02,8.203066e+00 C1.344444e+02,8.694139e+00 1.522222e+02,9.167786e+00 1.700000e+02,1.019904e+01 C1.877778e+02,1.123029e+01 2.055556e+02,1.222495e+01 2.233333e+02,1.439059e+01 C2.411111e+02,1.655622e+01 2.588889e+02,1.864500e+01 2.766667e+02,2.319283e+01 C2.944444e+02,2.774066e+01 3.122222e+02,3.212711e+01 3.300000e+02,4.167755e+01 C3.477778e+02,5.122798e+01 3.655556e+02,6.043953e+01 3.833333e+02,8.049545e+01 C4.011111e+02,1.005514e+02 4.188889e+02,1.198956e+02 4.366667e+02,1.620130e+02 C4.544444e+02,2.041305e+02 4.811111e+02,3.046688e+02 4.900000e+02,3.332000e+02 \"/></g><g stroke=\"hsl(152, 76%, 65%)\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-width=\"3px\" stroke-linejoin=\"round\" marker-start=\"url(#filled-circle)\" marker-mid=\"url(#filled-circle)\" marker-end=\"url(#filled-circle)\" fill=\"none\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,2.311058e+02 C1.888889e+01,2.395117e+02 4.555556e+01,2.930900e+02 6.333333e+01,2.815410e+02 C8.111111e+01,2.699919e+02 9.888889e+01,1.652558e+02 1.166667e+02,1.618115e+02 C1.344444e+02,1.583672e+02 1.522222e+02,2.464390e+02 1.700000e+02,2.608752e+02 C1.877778e+02,2.753114e+02 2.055556e+02,2.461016e+02 2.233333e+02,2.484287e+02 C2.411111e+02,2.507559e+02 2.588889e+02,2.730779e+02 2.766667e+02,2.748379e+02 C2.944444e+02,2.765980e+02 3.122222e+02,2.606821e+02 3.300000e+02,2.589888e+02 C3.477778e+02,2.572955e+02 3.655556e+02,2.638599e+02 3.833333e+02,2.646782e+02 C4.011111e+02,2.654965e+02 4.188889e+02,2.622838e+02 4.366667e+02,2.638986e+02 C4.544444e+02,2.655133e+02 4.811111e+02,2.726220e+02 4.900000e+02,2.743666e+02 \"/></g><g fill=\"none\" stroke-width=\"2px\" stroke-linejoin=\"round\" stroke=\"black\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,0 L10,-6 M6.333333e+01,0 L6.333333e+01,-6 M1.166667e+02,0 L1.166667e+02,-6 M170,0 L170,-6 M2.233333e+02,0 L2.233333e+02,-6 M2.766667e+02,0 L2.766667e+02,-6 M330,0 L330,-6 M3.833333e+02,0 L3.833333e+02,-6 M4.366667e+02,0 L4.366667e+02,-6 M490,0 L490,-6 \"/></g><g stroke-linecap=\"round\" font-style=\"normal\" dominant-baseline=\"hanging\" stroke=\"black\" transform=\"translate(70 410 )scale(1 1 )\" font-family=\"sans-serif\" font-weight=\"normal\" fill=\"black\" stroke-width=\"2px\" stroke-linejoin=\"round\" font-size=\"12px\" text-anchor=\"middle\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"10\" y=\"10\" dominant-baseline=\"hanging\">1</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"6.333333e+01\" y=\"10\" dominant-baseline=\"hanging\">2</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"1.166667e+02\">3</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"10\" dominant-baseline=\"hanging\">4</text><text vector-effect=\"non-scaling-stroke\" x=\"2.233333e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">5</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.766667e+02\" y=\"10\" dominant-baseline=\"hanging\">6</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"330\" y=\"10\" dominant-baseline=\"hanging\">7</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"3.833333e+02\" y=\"10\" dominant-baseline=\"hanging\">8</text><text vector-effect=\"non-scaling-stroke\" x=\"4.366667e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">9</text><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"490\" y=\"10\">10</text></g><g stroke-linejoin=\"round\" font-weight=\"bold\" text-anchor=\"middle\" dominant-baseline=\"baseline\" stroke=\"black\" stroke-linecap=\"round\" fill=\"black\" stroke-width=\"2px\" font-size=\"12px\" font-style=\"normal\" transform=\"translate(70 410 )scale(1 1 )rotate(0 0 0 )\" font-family=\"sans-serif\"><text vector-effect=\"non-scaling-stroke\" x=\"250\" y=\"-6\" dominant-baseline=\"baseline\" stroke=\"none\">X</text></g><g stroke-width=\"2px\" stroke-linejoin=\"round\" font-size=\"12px\" text-anchor=\"middle\" stroke=\"black\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" font-family=\"sans-serif\" font-weight=\"bold\" dominant-baseline=\"baseline\" fill=\"black\" font-style=\"normal\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L-6,2.472591e+01 M0,5.860766e+01 L-6,5.860766e+01 M0,9.248942e+01 L-6,9.248942e+01 M0,1.263712e+02 L-6,1.263712e+02 M0,1.602529e+02 L-6,1.602529e+02 M0,1.941347e+02 L-6,1.941347e+02 M0,2.280164e+02 L-6,2.280164e+02 M0,2.618982e+02 L-6,2.618982e+02 M0,2.957799e+02 L-6,2.957799e+02 M0,3.296617e+02 L-6,3.296617e+02 \"/></g><g stroke-width=\"2px\" stroke=\"black\" transform=\"translate(70 410 )scale(1 1 )\" fill=\"black\" stroke-linejoin=\"round\" font-size=\"12px\" font-style=\"normal\" text-anchor=\"end\" dominant-baseline=\"middle\" stroke-linecap=\"round\" font-family=\"sans-serif\" font-weight=\"normal\"><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.472591e+01\">1.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-5.860766e+01\">2.0</text><text x=\"-10\" y=\"-9.248942e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">4.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.263712e+02\" dominant-baseline=\"middle\">8.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.602529e+02\">16.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.941347e+02\" dominant-baseline=\"middle\">32.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.280164e+02\">64.0</text><text y=\"-2.618982e+02\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">128.0</text><text vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.957799e+02\" dominant-baseline=\"middle\" stroke=\"none\">256.0</text><text dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-3.296617e+02\">512.0</text></g><g stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )rotate(-90 0 0 )\" font-family=\"sans-serif\" font-weight=\"bold\" fill=\"black\" stroke-linejoin=\"round\" font-style=\"normal\" text-anchor=\"middle\" dominant-baseline=\"hanging\" stroke-width=\"2px\" font-size=\"12px\" stroke=\"black\"><text x=\"170\" y=\"6\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">Y</text></g><g stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" font-family=\"sans-serif\" stroke-width=\"0.5px\" stroke-linejoin=\"round\" text-anchor=\"middle\" stroke=\"gray\" font-weight=\"bold\" fill=\"black\" font-size=\"12px\" font-style=\"normal\" dominant-baseline=\"hanging\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L500,2.472591e+01 M0,5.860766e+01 L500,5.860766e+01 M0,9.248942e+01 L500,9.248942e+01 M0,1.263712e+02 L500,1.263712e+02 M0,1.602529e+02 L500,1.602529e+02 M0,1.941347e+02 L500,1.941347e+02 M0,2.280164e+02 L500,2.280164e+02 M0,2.618982e+02 L500,2.618982e+02 M0,2.957799e+02 L500,2.957799e+02 M0,3.296617e+02 L500,3.296617e+02 \"/></g><g stroke=\"black\" stroke-linecap=\"round\" font-weight=\"bold\" font-size=\"12px\" font-style=\"normal\" stroke-linejoin=\"round\" text-anchor=\"middle\" dominant-baseline=\"hanging\" font-family=\"sans-serif\" fill=\"none\" stroke-width=\"2px\"><rect height=\"340\" vector-effect=\"non-scaling-stroke\" x=\"70\" y=\"70\" width=\"500\"/><g dominant-baseline=\"middle\" fill=\"black\" font-size=\"18px\"><text y=\"35\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"320\">A diagram of sorts 📊 📈</text></g></g></svg></div>"
+       "<div><svg viewbox=\"0 0 640 480\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"640\" height=\"480\"><defs><marker markerWidth=\"2%\" markerHeight=\"2%\" id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\"><circle r=\"3\" fill=\"none\" stroke=\"black\" cx=\"5\" cy=\"5\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \"><circle fill=\"black\" stroke=\"none\" cx=\"5\" cy=\"5\" r=\"3\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"square\" viewBox=\"0 0 10 10 \"><rect y=\"2\" width=\"6\" height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\"><rect height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\" y=\"2\" width=\"6\"/></marker></defs><g fill=\"none\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-linejoin=\"round\" marker-end=\"url(#square)\" marker-start=\"url(#square)\" stroke=\"hsl(90, 47%, 65%)\" stroke-width=\"1px\" marker-mid=\"url(#square)\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,6.800000e+00 L6.333333e+01,4.306667e+01 L1.166667e+02,7.933333e+01 L170,1.156000e+02 L2.233333e+02,1.518667e+02 L2.766667e+02,1.881333e+02 L330,2.244000e+02 L3.833333e+02,2.606667e+02 L4.366667e+02,2.969333e+02 L490,3.332000e+02 \"/></g><g stroke=\"hsl(301, 88%, 65%)\" stroke-width=\"3.14px\" stroke-linejoin=\"round\" fill=\"none\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,6.800000e+00 C1.888889e+01,6.875434e+00 4.555556e+01,7.018758e+00 6.333333e+01,7.252602e+00 C8.111111e+01,7.486446e+00 9.888889e+01,7.711993e+00 1.166667e+02,8.203066e+00 C1.344444e+02,8.694139e+00 1.522222e+02,9.167786e+00 1.700000e+02,1.019904e+01 C1.877778e+02,1.123029e+01 2.055556e+02,1.222495e+01 2.233333e+02,1.439059e+01 C2.411111e+02,1.655622e+01 2.588889e+02,1.864500e+01 2.766667e+02,2.319283e+01 C2.944444e+02,2.774066e+01 3.122222e+02,3.212711e+01 3.300000e+02,4.167755e+01 C3.477778e+02,5.122798e+01 3.655556e+02,6.043953e+01 3.833333e+02,8.049545e+01 C4.011111e+02,1.005514e+02 4.188889e+02,1.198956e+02 4.366667e+02,1.620130e+02 C4.544444e+02,2.041305e+02 4.811111e+02,3.046688e+02 4.900000e+02,3.332000e+02 \"/></g><g marker-mid=\"url(#filled-circle)\" stroke-linecap=\"round\" marker-start=\"url(#filled-circle)\" transform=\"translate(70 410 )scale(1 -1 )\" stroke-linejoin=\"round\" fill=\"none\" stroke=\"hsl(152, 76%, 65%)\" stroke-width=\"3px\" marker-end=\"url(#filled-circle)\"><path vector-effect=\"non-scaling-stroke\" d=\"M1.000000e+01,2.238017e+02 C1.888889e+01,2.333421e+02 4.555556e+01,2.723836e+02 6.333333e+01,2.810439e+02 C8.111111e+01,2.897043e+02 9.888889e+01,2.842325e+02 1.166667e+02,2.757638e+02 C1.344444e+02,2.672951e+02 1.522222e+02,2.452773e+02 1.700000e+02,2.302318e+02 C1.877778e+02,2.151863e+02 2.055556e+02,1.787898e+02 2.233333e+02,1.854907e+02 C2.411111e+02,1.921916e+02 2.588889e+02,2.665045e+02 2.766667e+02,2.704371e+02 C2.944444e+02,2.743696e+02 3.122222e+02,2.156400e+02 3.300000e+02,2.090860e+02 C3.477778e+02,2.025320e+02 3.655556e+02,2.381129e+02 3.833333e+02,2.311130e+02 C4.011111e+02,2.241130e+02 4.188889e+02,1.615127e+02 4.366667e+02,1.670862e+02 C4.544444e+02,1.726597e+02 4.811111e+02,2.483094e+02 4.900000e+02,2.645540e+02 \"/></g><g stroke=\"black\" stroke-width=\"2px\" stroke-linejoin=\"round\" fill=\"none\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M10,0 L10,-6 M6.333333e+01,0 L6.333333e+01,-6 M1.166667e+02,0 L1.166667e+02,-6 M170,0 L170,-6 M2.233333e+02,0 L2.233333e+02,-6 M2.766667e+02,0 L2.766667e+02,-6 M330,0 L330,-6 M3.833333e+02,0 L3.833333e+02,-6 M4.366667e+02,0 L4.366667e+02,-6 M490,0 L490,-6 \"/></g><g stroke-linecap=\"round\" fill=\"black\" font-style=\"normal\" text-anchor=\"middle\" stroke-width=\"2px\" stroke-linejoin=\"round\" font-weight=\"normal\" transform=\"translate(70 410 )scale(1 1 )\" font-family=\"sans-serif\" font-size=\"12px\" dominant-baseline=\"hanging\" stroke=\"black\"><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"10\" y=\"10\">1</text><text y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"6.333333e+01\">2</text><text vector-effect=\"non-scaling-stroke\" x=\"1.166667e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">3</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"10\" dominant-baseline=\"hanging\">4</text><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"2.233333e+02\" y=\"10\">5</text><text vector-effect=\"non-scaling-stroke\" x=\"2.766667e+02\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\">6</text><text x=\"330\" y=\"10\" dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">7</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"3.833333e+02\" y=\"10\" dominant-baseline=\"hanging\">8</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"4.366667e+02\" y=\"10\" dominant-baseline=\"hanging\">9</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"490\" y=\"10\" dominant-baseline=\"hanging\">10</text></g><g stroke-width=\"2px\" stroke-linejoin=\"round\" font-style=\"normal\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )rotate(0 0 0 )\" stroke=\"black\" dominant-baseline=\"baseline\" font-family=\"sans-serif\" font-size=\"12px\" text-anchor=\"middle\" fill=\"black\" font-weight=\"bold\"><text y=\"-6\" dominant-baseline=\"baseline\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"250\">X</text></g><g font-weight=\"bold\" stroke=\"black\" stroke-width=\"2px\" stroke-linejoin=\"round\" font-size=\"12px\" font-style=\"normal\" transform=\"translate(70 410 )scale(1 -1 )\" dominant-baseline=\"baseline\" font-family=\"sans-serif\" text-anchor=\"middle\" fill=\"black\" stroke-linecap=\"round\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L-6,2.472591e+01 M0,5.860766e+01 L-6,5.860766e+01 M0,9.248942e+01 L-6,9.248942e+01 M0,1.263712e+02 L-6,1.263712e+02 M0,1.602529e+02 L-6,1.602529e+02 M0,1.941347e+02 L-6,1.941347e+02 M0,2.280164e+02 L-6,2.280164e+02 M0,2.618982e+02 L-6,2.618982e+02 M0,2.957799e+02 L-6,2.957799e+02 M0,3.296617e+02 L-6,3.296617e+02 \"/></g><g dominant-baseline=\"middle\" font-style=\"normal\" text-anchor=\"end\" font-family=\"sans-serif\" stroke=\"black\" stroke-linejoin=\"round\" font-weight=\"normal\" fill=\"black\" stroke-linecap=\"round\" transform=\"translate(70 410 )scale(1 1 )\" font-size=\"12px\" stroke-width=\"2px\"><text x=\"-10\" y=\"-2.472591e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">1.0</text><text y=\"-5.860766e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">2.0</text><text y=\"-9.248942e+01\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\">4.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.263712e+02\" dominant-baseline=\"middle\">8.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.602529e+02\" dominant-baseline=\"middle\">16.0</text><text vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-1.941347e+02\" dominant-baseline=\"middle\" stroke=\"none\">32.0</text><text vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.280164e+02\" dominant-baseline=\"middle\" stroke=\"none\">64.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.618982e+02\" dominant-baseline=\"middle\">128.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-2.957799e+02\" dominant-baseline=\"middle\">256.0</text><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"-10\" y=\"-3.296617e+02\" dominant-baseline=\"middle\">512.0</text></g><g stroke=\"black\" font-family=\"sans-serif\" font-style=\"normal\" stroke-linejoin=\"round\" font-weight=\"bold\" transform=\"translate(70 410 )scale(1 1 )rotate(-90 0 0 )\" font-size=\"12px\" text-anchor=\"middle\" fill=\"black\" stroke-linecap=\"round\" dominant-baseline=\"hanging\" stroke-width=\"2px\"><text dominant-baseline=\"hanging\" stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"170\" y=\"6\">Y</text></g><g text-anchor=\"middle\" fill=\"black\" stroke-linecap=\"round\" font-weight=\"bold\" stroke=\"gray\" stroke-width=\"0.5px\" stroke-linejoin=\"round\" dominant-baseline=\"hanging\" font-style=\"normal\" transform=\"translate(70 410 )scale(1 -1 )\" font-family=\"sans-serif\" font-size=\"12px\"><path vector-effect=\"non-scaling-stroke\" d=\"M0,2.472591e+01 L500,2.472591e+01 M0,5.860766e+01 L500,5.860766e+01 M0,9.248942e+01 L500,9.248942e+01 M0,1.263712e+02 L500,1.263712e+02 M0,1.602529e+02 L500,1.602529e+02 M0,1.941347e+02 L500,1.941347e+02 M0,2.280164e+02 L500,2.280164e+02 M0,2.618982e+02 L500,2.618982e+02 M0,2.957799e+02 L500,2.957799e+02 M0,3.296617e+02 L500,3.296617e+02 \"/></g><g font-weight=\"bold\" fill=\"none\" font-family=\"sans-serif\" font-size=\"12px\" stroke-linecap=\"round\" stroke=\"black\" stroke-width=\"2px\" stroke-linejoin=\"round\" dominant-baseline=\"hanging\" font-style=\"normal\" text-anchor=\"middle\"><rect x=\"70\" y=\"70\" width=\"500\" height=\"340\" vector-effect=\"non-scaling-stroke\"/><g dominant-baseline=\"middle\" font-size=\"18px\" fill=\"black\"><text vector-effect=\"non-scaling-stroke\" x=\"320\" y=\"35\" dominant-baseline=\"middle\" stroke=\"none\">A diagram of sorts 📊 📈</text></g></g></svg></div>"
       ]
      },
      "metadata": {},
@@ -669,7 +679,7 @@
     {
      "data": {
       "text/html": [
-       "<svg height=\"400\" viewbox=\"0 0 1024 400\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"1024\"><defs><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"circle\" viewBox=\"0 0 10 10 \" refX=\"5\"><circle cx=\"5\" cy=\"5\" r=\"3\" fill=\"none\" stroke=\"black\"/></marker><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \"><circle cy=\"5\" r=\"3\" fill=\"black\" stroke=\"none\" cx=\"5\"/></marker><marker id=\"square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><rect x=\"2\" y=\"2\" width=\"6\" height=\"6\" fill=\"none\" stroke=\"black\"/></marker><marker id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><rect fill=\"black\" stroke=\"none\" x=\"2\" y=\"2\" width=\"6\" height=\"6\"/></marker></defs><g fill=\"none\" stroke=\"hsl(198, 47%, 65%)\" stroke-width=\"3.14px\" stroke-linecap=\"round\" stroke-linejoin=\"round\" transform=\"translate(64 336 )scale(1 -1 )\"><path vector-effect=\"non-scaling-stroke\" d=\"M0.000000e+00,1.360312e+02 C1.508418e+00,1.499049e+02 6.033670e+00,1.968203e+02 9.050505e+00,2.192736e+02 C1.206734e+01,2.417269e+02 1.508418e+01,2.621600e+02 1.810101e+01,2.707510e+02 C2.111785e+01,2.793420e+02 2.413468e+01,2.793693e+02 2.715152e+01,2.708197e+02 C3.016835e+01,2.622702e+02 3.318519e+01,2.418813e+02 3.620202e+01,2.194536e+02 C3.921886e+01,1.970259e+02 4.223569e+01,1.640012e+02 4.525253e+01,1.362537e+02 C4.826936e+01,1.085063e+02 5.128620e+01,7.544786e+01 5.430303e+01,5.296898e+01 C5.731987e+01,3.049010e+01 6.033670e+01,1.001293e+01 6.335354e+01,1.380483e+00 C6.637037e+01,-7.251970e+00 6.938721e+01,-7.333825e+00 7.240404e+01,1.174264e+00 C7.542088e+01,9.682353e+00 7.843771e+01,3.002705e+01 8.145455e+01,5.242902e+01 C8.447138e+01,7.483099e+01 8.748822e+01,1.078388e+02 9.050505e+01,1.355861e+02 C9.352189e+01,1.633334e+02 9.653872e+01,1.964086e+02 9.955556e+01,2.189130e+02 C1.025724e+02,2.414174e+02 1.055892e+02,2.619386e+02 1.086061e+02,2.706125e+02 C1.116229e+02,2.792864e+02 1.146397e+02,2.794228e+02 1.176566e+02,2.709562e+02 C1.206734e+02,2.624896e+02 1.236902e+02,2.421892e+02 1.267071e+02,2.198130e+02 C1.297239e+02,1.974367e+02 1.327407e+02,1.644460e+02 1.357576e+02,1.366989e+02 C1.387744e+02,1.089517e+02 1.417912e+02,7.585985e+01 1.448081e+02,5.332998e+01 C1.478249e+02,3.080011e+01 1.508418e+02,1.023488e+01 1.538586e+02,1.519623e+00 C1.568754e+02,-7.195632e+00 1.598923e+02,-7.386626e+00 1.629091e+02,1.038449e+00 C1.659259e+02,9.463524e+00 1.689428e+02,2.971965e+01 1.719596e+02,5.207007e+01 C1.749764e+02,7.442050e+01 1.779933e+02,1.073941e+02 1.810101e+02,1.351410e+02 C1.840269e+02,1.628879e+02 1.870438e+02,1.959963e+02 1.900606e+02,2.185516e+02 C1.930774e+02,2.411069e+02 1.960943e+02,2.617161e+02 1.991111e+02,2.704727e+02 C2.021279e+02,2.792293e+02 2.051448e+02,2.794749e+02 2.081616e+02,2.710914e+02 C2.111785e+02,2.627078e+02 2.141953e+02,2.424960e+02 2.172121e+02,2.201715e+02 C2.202290e+02,1.978469e+02 2.232458e+02,1.648906e+02 2.262626e+02,1.371440e+02 C2.292795e+02,1.093973e+02 2.322963e+02,7.627244e+01 2.353131e+02,5.369180e+01 C2.383300e+02,3.111115e+01 2.413468e+02,1.045806e+01 2.443636e+02,1.660091e+00 C2.473805e+02,-7.137881e+00 2.503973e+02,-7.438012e+00 2.534141e+02,9.039661e-01 C2.564310e+02,9.245944e+00 2.594478e+02,2.941330e+01 2.624646e+02,5.171196e+01 C2.654815e+02,7.401061e+01 2.684983e+02,1.069497e+02 2.715152e+02,1.346959e+02 C2.745320e+02,1.624421e+02 2.775488e+02,1.955834e+02 2.805657e+02,2.181894e+02 C2.835825e+02,2.407953e+02 2.865993e+02,2.614923e+02 2.896162e+02,2.703316e+02 C2.926330e+02,2.791709e+02 2.956498e+02,2.795256e+02 2.986667e+02,2.712252e+02 C3.016835e+02,2.629248e+02 3.047003e+02,2.428019e+02 3.077172e+02,2.205292e+02 C3.107340e+02,1.982565e+02 3.137508e+02,1.653348e+02 3.167677e+02,1.375890e+02 C3.197845e+02,1.098432e+02 3.228013e+02,7.668562e+01 3.258182e+02,5.405442e+01 C3.288350e+02,3.142323e+01 3.318519e+02,1.068249e+01 3.348687e+02,1.801885e+00 C3.378855e+02,-7.078717e+00 3.409024e+02,-7.487981e+00 3.439192e+02,7.708167e-01 C3.469360e+02,9.029615e+00 3.499529e+02,2.910801e+01 3.529697e+02,5.135467e+01 C3.559865e+02,7.360134e+01 3.590034e+02,1.065055e+02 3.620202e+02,1.342508e+02 C3.650370e+02,1.619961e+02 3.680539e+02,1.951700e+02 3.710707e+02,2.178263e+02 C3.740875e+02,2.404827e+02 3.771044e+02,2.612672e+02 3.801212e+02,2.701891e+02 C3.831380e+02,2.791110e+02 3.861549e+02,2.795748e+02 3.891717e+02,2.713576e+02 C3.921886e+02,2.631405e+02 3.952054e+02,2.431066e+02 3.982222e+02,2.208860e+02 C4.012391e+02,1.986655e+02 4.042559e+02,1.657788e+02 4.072727e+02,1.380341e+02 C4.102896e+02,1.102894e+02 4.133064e+02,7.709938e+01 4.163232e+02,5.441786e+01 C4.193401e+02,3.173635e+01 4.223569e+02,1.090815e+01 4.253737e+02,1.945003e+00 C4.283906e+02,-7.018140e+00 4.314074e+02,-7.536535e+00 4.344242e+02,6.390024e-01 C4.374411e+02,8.814539e+00 4.404579e+02,2.880377e+01 4.434747e+02,5.099823e+01 C4.464916e+02,7.319268e+01 4.495084e+02,1.060617e+02 4.525253e+02,1.338058e+02 C4.555421e+02,1.615498e+02 4.585589e+02,1.947559e+02 4.615758e+02,2.174625e+02 C4.645926e+02,2.401691e+02 4.676094e+02,2.610410e+02 4.706263e+02,2.700453e+02 C4.736431e+02,2.790497e+02 4.766599e+02,2.796227e+02 4.796768e+02,2.714888e+02 C4.826936e+02,2.633549e+02 4.857104e+02,2.434103e+02 4.887273e+02,2.212421e+02 C4.917441e+02,1.990738e+02 4.947609e+02,1.662225e+02 4.977778e+02,1.384792e+02 C5.007946e+02,1.107358e+02 5.038114e+02,7.751373e+01 5.068283e+02,5.478211e+01 C5.098451e+02,3.205049e+01 5.128620e+02,1.113504e+01 5.158788e+02,2.089446e+00 C5.188956e+02,-6.956152e+00 5.219125e+02,-7.583671e+00 5.249293e+02,5.085242e-01 C5.279461e+02,8.600720e+00 5.309630e+02,2.850059e+01 5.339798e+02,5.064262e+01 C5.369966e+02,7.278465e+01 5.400135e+02,1.056182e+02 5.430303e+02,1.333607e+02 C5.460471e+02,1.611033e+02 5.490640e+02,1.943413e+02 5.520808e+02,2.170979e+02 C5.550976e+02,2.398544e+02 5.581145e+02,2.608134e+02 5.611313e+02,2.699002e+02 C5.641481e+02,2.789870e+02 5.671650e+02,2.796691e+02 5.701818e+02,2.716186e+02 C5.731987e+02,2.635681e+02 5.762155e+02,2.437130e+02 5.792323e+02,2.215973e+02 C5.822492e+02,1.994815e+02 5.852660e+02,1.666659e+02 5.882828e+02,1.389242e+02 C5.912997e+02,1.111825e+02 5.943165e+02,7.792865e+01 5.973333e+02,5.514715e+01 C6.003502e+02,3.236566e+01 6.033670e+02,1.136317e+01 6.063838e+02,2.235210e+00 C6.094007e+02,-6.892752e+00 6.124175e+02,-7.629390e+00 6.154343e+02,3.793837e-01 C6.184512e+02,8.388157e+00 6.214680e+02,2.819847e+01 6.244848e+02,5.028785e+01 C6.275017e+02,7.237724e+01 6.305185e+02,1.051749e+02 6.335354e+02,1.329157e+02 C6.365522e+02,1.606565e+02 6.395690e+02,1.939261e+02 6.425859e+02,2.167324e+02 C6.456027e+02,2.395388e+02 6.486195e+02,2.605847e+02 6.516364e+02,2.697538e+02 C6.546532e+02,2.789229e+02 6.576700e+02,2.797141e+02 6.606869e+02,2.717471e+02 C6.637037e+02,2.637800e+02 6.667205e+02,2.440146e+02 6.697374e+02,2.219516e+02 C6.727542e+02,1.998886e+02 6.757710e+02,1.671090e+02 6.787879e+02,1.393692e+02 C6.818047e+02,1.116294e+02 6.848215e+02,7.834414e+01 6.878384e+02,5.551300e+01 C6.908552e+02,3.268185e+01 6.938721e+02,1.159253e+01 6.968889e+02,2.382294e+00 C6.999057e+02,-6.827941e+00 7.029226e+02,-7.673691e+00 7.059394e+02,2.515819e-01 C7.089562e+02,8.176855e+00 7.119731e+02,2.789741e+01 7.149899e+02,4.993393e+01 C7.180067e+02,7.197046e+01 7.210236e+02,1.047320e+02 7.240404e+02,1.324707e+02 C7.270572e+02,1.602094e+02 7.300741e+02,1.935103e+02 7.330909e+02,2.163662e+02 C7.361077e+02,2.392221e+02 7.391246e+02,2.603547e+02 7.421414e+02,2.696061e+02 C7.451582e+02,2.788574e+02 7.481751e+02,2.797577e+02 7.511919e+02,2.718742e+02 C7.542088e+02,2.639907e+02 7.572256e+02,2.443151e+02 7.602424e+02,2.223051e+02 C7.632593e+02,2.002951e+02 7.662761e+02,1.675517e+02 7.692929e+02,1.398141e+02 C7.723098e+02,1.120766e+02 7.753266e+02,7.876021e+01 7.783434e+02,5.587964e+01 C7.813603e+02,3.299906e+01 7.843771e+02,1.182312e+01 7.873939e+02,2.530698e+00 C7.904108e+02,-6.761721e+00 7.934276e+02,-7.716574e+00 7.964444e+02,1.251203e-01 C7.994613e+02,7.966814e+00 8.024781e+02,2.759742e+01 8.054949e+02,4.958086e+01 C8.085118e+02,7.156431e+01 8.115286e+02,1.042894e+02 8.145455e+02,1.320258e+02 C8.175623e+02,1.597622e+02 8.205791e+02,1.930939e+02 8.235960e+02,2.159991e+02 C8.266128e+02,2.389043e+02 8.296296e+02,2.601235e+02 8.326465e+02,2.694570e+02 C8.356633e+02,2.787905e+02 8.386801e+02,2.797999e+02 8.416970e+02,2.720000e+02 C8.447138e+02,2.642001e+02 8.477306e+02,2.446146e+02 8.507475e+02,2.226577e+02 C8.537643e+02,2.007009e+02 8.567811e+02,1.679942e+02 8.597980e+02,1.402591e+02 C8.628148e+02,1.125240e+02 8.658316e+02,7.917684e+01 8.688485e+02,5.624706e+01 C8.718653e+02,3.331729e+01 8.748822e+02,1.205493e+01 8.778990e+02,2.680419e+00 C8.809158e+02,-6.694092e+00 8.839327e+02,-7.758038e+00 8.869495e+02,0.000000e+00 C8.899663e+02,7.758038e+00 8.944916e+02,4.102387e+01 8.960000e+02,4.922865e+01 \"/></g><g fill=\"none\" stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect vector-effect=\"non-scaling-stroke\" x=\"64\" y=\"64\" width=\"896\" height=\"272\"/><g font-size=\"18px\" font-style=\"normal\" font-family=\"sans-serif\" text-anchor=\"middle\" dominant-baseline=\"middle\" font-weight=\"bold\" fill=\"black\"><text x=\"512\" y=\"32\" dominant-baseline=\"middle\" stroke=\"none\" vector-effect=\"non-scaling-stroke\">Animated Sine</text></g></g></svg>"
+       "<svg height=\"400\" viewbox=\"0 0 1024 400\" style=\"background-color:#f8f8f8\" preserveAspectRatio=\"xMidYMid meet\" xmlns=\"http://www.w3.org/2000/svg\" width=\"1024\"><defs><marker refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"circle\" viewBox=\"0 0 10 10 \"><circle stroke=\"black\" cx=\"5\" cy=\"5\" r=\"3\" fill=\"none\"/></marker><marker markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-circle\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\"><circle r=\"3\" fill=\"black\" stroke=\"none\" cx=\"5\" cy=\"5\"/></marker><marker id=\"square\" viewBox=\"0 0 10 10 \" refX=\"5\" refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\"><rect height=\"6\" fill=\"none\" stroke=\"black\" x=\"2\" y=\"2\" width=\"6\"/></marker><marker refY=\"5\" markerUnits=\"userSpaceOnUse\" markerWidth=\"2%\" markerHeight=\"2%\" id=\"filled-square\" viewBox=\"0 0 10 10 \" refX=\"5\"><rect width=\"6\" height=\"6\" fill=\"black\" stroke=\"none\" x=\"2\" y=\"2\"/></marker></defs><g stroke-width=\"3.14px\" stroke-linecap=\"round\" stroke-linejoin=\"round\" transform=\"translate(64 336 )scale(1 -1 )\" fill=\"none\" stroke=\"hsl(198, 47%, 65%)\"><path vector-effect=\"non-scaling-stroke\" d=\"M0.000000e+00,1.360312e+02 C1.508418e+00,1.499049e+02 6.033670e+00,1.968203e+02 9.050505e+00,2.192736e+02 C1.206734e+01,2.417269e+02 1.508418e+01,2.621600e+02 1.810101e+01,2.707510e+02 C2.111785e+01,2.793420e+02 2.413468e+01,2.793693e+02 2.715152e+01,2.708197e+02 C3.016835e+01,2.622702e+02 3.318519e+01,2.418813e+02 3.620202e+01,2.194536e+02 C3.921886e+01,1.970259e+02 4.223569e+01,1.640012e+02 4.525253e+01,1.362537e+02 C4.826936e+01,1.085063e+02 5.128620e+01,7.544786e+01 5.430303e+01,5.296898e+01 C5.731987e+01,3.049010e+01 6.033670e+01,1.001293e+01 6.335354e+01,1.380483e+00 C6.637037e+01,-7.251970e+00 6.938721e+01,-7.333825e+00 7.240404e+01,1.174264e+00 C7.542088e+01,9.682353e+00 7.843771e+01,3.002705e+01 8.145455e+01,5.242902e+01 C8.447138e+01,7.483099e+01 8.748822e+01,1.078388e+02 9.050505e+01,1.355861e+02 C9.352189e+01,1.633334e+02 9.653872e+01,1.964086e+02 9.955556e+01,2.189130e+02 C1.025724e+02,2.414174e+02 1.055892e+02,2.619386e+02 1.086061e+02,2.706125e+02 C1.116229e+02,2.792864e+02 1.146397e+02,2.794228e+02 1.176566e+02,2.709562e+02 C1.206734e+02,2.624896e+02 1.236902e+02,2.421892e+02 1.267071e+02,2.198130e+02 C1.297239e+02,1.974367e+02 1.327407e+02,1.644460e+02 1.357576e+02,1.366989e+02 C1.387744e+02,1.089517e+02 1.417912e+02,7.585985e+01 1.448081e+02,5.332998e+01 C1.478249e+02,3.080011e+01 1.508418e+02,1.023488e+01 1.538586e+02,1.519623e+00 C1.568754e+02,-7.195632e+00 1.598923e+02,-7.386626e+00 1.629091e+02,1.038449e+00 C1.659259e+02,9.463524e+00 1.689428e+02,2.971965e+01 1.719596e+02,5.207007e+01 C1.749764e+02,7.442050e+01 1.779933e+02,1.073941e+02 1.810101e+02,1.351410e+02 C1.840269e+02,1.628879e+02 1.870438e+02,1.959963e+02 1.900606e+02,2.185516e+02 C1.930774e+02,2.411069e+02 1.960943e+02,2.617161e+02 1.991111e+02,2.704727e+02 C2.021279e+02,2.792293e+02 2.051448e+02,2.794749e+02 2.081616e+02,2.710914e+02 C2.111785e+02,2.627078e+02 2.141953e+02,2.424960e+02 2.172121e+02,2.201715e+02 C2.202290e+02,1.978469e+02 2.232458e+02,1.648906e+02 2.262626e+02,1.371440e+02 C2.292795e+02,1.093973e+02 2.322963e+02,7.627244e+01 2.353131e+02,5.369180e+01 C2.383300e+02,3.111115e+01 2.413468e+02,1.045806e+01 2.443636e+02,1.660091e+00 C2.473805e+02,-7.137881e+00 2.503973e+02,-7.438012e+00 2.534141e+02,9.039661e-01 C2.564310e+02,9.245944e+00 2.594478e+02,2.941330e+01 2.624646e+02,5.171196e+01 C2.654815e+02,7.401061e+01 2.684983e+02,1.069497e+02 2.715152e+02,1.346959e+02 C2.745320e+02,1.624421e+02 2.775488e+02,1.955834e+02 2.805657e+02,2.181894e+02 C2.835825e+02,2.407953e+02 2.865993e+02,2.614923e+02 2.896162e+02,2.703316e+02 C2.926330e+02,2.791709e+02 2.956498e+02,2.795256e+02 2.986667e+02,2.712252e+02 C3.016835e+02,2.629248e+02 3.047003e+02,2.428019e+02 3.077172e+02,2.205292e+02 C3.107340e+02,1.982565e+02 3.137508e+02,1.653348e+02 3.167677e+02,1.375890e+02 C3.197845e+02,1.098432e+02 3.228013e+02,7.668562e+01 3.258182e+02,5.405442e+01 C3.288350e+02,3.142323e+01 3.318519e+02,1.068249e+01 3.348687e+02,1.801885e+00 C3.378855e+02,-7.078717e+00 3.409024e+02,-7.487981e+00 3.439192e+02,7.708167e-01 C3.469360e+02,9.029615e+00 3.499529e+02,2.910801e+01 3.529697e+02,5.135467e+01 C3.559865e+02,7.360134e+01 3.590034e+02,1.065055e+02 3.620202e+02,1.342508e+02 C3.650370e+02,1.619961e+02 3.680539e+02,1.951700e+02 3.710707e+02,2.178263e+02 C3.740875e+02,2.404827e+02 3.771044e+02,2.612672e+02 3.801212e+02,2.701891e+02 C3.831380e+02,2.791110e+02 3.861549e+02,2.795748e+02 3.891717e+02,2.713576e+02 C3.921886e+02,2.631405e+02 3.952054e+02,2.431066e+02 3.982222e+02,2.208860e+02 C4.012391e+02,1.986655e+02 4.042559e+02,1.657788e+02 4.072727e+02,1.380341e+02 C4.102896e+02,1.102894e+02 4.133064e+02,7.709938e+01 4.163232e+02,5.441786e+01 C4.193401e+02,3.173635e+01 4.223569e+02,1.090815e+01 4.253737e+02,1.945003e+00 C4.283906e+02,-7.018140e+00 4.314074e+02,-7.536535e+00 4.344242e+02,6.390024e-01 C4.374411e+02,8.814539e+00 4.404579e+02,2.880377e+01 4.434747e+02,5.099823e+01 C4.464916e+02,7.319268e+01 4.495084e+02,1.060617e+02 4.525253e+02,1.338058e+02 C4.555421e+02,1.615498e+02 4.585589e+02,1.947559e+02 4.615758e+02,2.174625e+02 C4.645926e+02,2.401691e+02 4.676094e+02,2.610410e+02 4.706263e+02,2.700453e+02 C4.736431e+02,2.790497e+02 4.766599e+02,2.796227e+02 4.796768e+02,2.714888e+02 C4.826936e+02,2.633549e+02 4.857104e+02,2.434103e+02 4.887273e+02,2.212421e+02 C4.917441e+02,1.990738e+02 4.947609e+02,1.662225e+02 4.977778e+02,1.384792e+02 C5.007946e+02,1.107358e+02 5.038114e+02,7.751373e+01 5.068283e+02,5.478211e+01 C5.098451e+02,3.205049e+01 5.128620e+02,1.113504e+01 5.158788e+02,2.089446e+00 C5.188956e+02,-6.956152e+00 5.219125e+02,-7.583671e+00 5.249293e+02,5.085242e-01 C5.279461e+02,8.600720e+00 5.309630e+02,2.850059e+01 5.339798e+02,5.064262e+01 C5.369966e+02,7.278465e+01 5.400135e+02,1.056182e+02 5.430303e+02,1.333607e+02 C5.460471e+02,1.611033e+02 5.490640e+02,1.943413e+02 5.520808e+02,2.170979e+02 C5.550976e+02,2.398544e+02 5.581145e+02,2.608134e+02 5.611313e+02,2.699002e+02 C5.641481e+02,2.789870e+02 5.671650e+02,2.796691e+02 5.701818e+02,2.716186e+02 C5.731987e+02,2.635681e+02 5.762155e+02,2.437130e+02 5.792323e+02,2.215973e+02 C5.822492e+02,1.994815e+02 5.852660e+02,1.666659e+02 5.882828e+02,1.389242e+02 C5.912997e+02,1.111825e+02 5.943165e+02,7.792865e+01 5.973333e+02,5.514715e+01 C6.003502e+02,3.236566e+01 6.033670e+02,1.136317e+01 6.063838e+02,2.235210e+00 C6.094007e+02,-6.892752e+00 6.124175e+02,-7.629390e+00 6.154343e+02,3.793837e-01 C6.184512e+02,8.388157e+00 6.214680e+02,2.819847e+01 6.244848e+02,5.028785e+01 C6.275017e+02,7.237724e+01 6.305185e+02,1.051749e+02 6.335354e+02,1.329157e+02 C6.365522e+02,1.606565e+02 6.395690e+02,1.939261e+02 6.425859e+02,2.167324e+02 C6.456027e+02,2.395388e+02 6.486195e+02,2.605847e+02 6.516364e+02,2.697538e+02 C6.546532e+02,2.789229e+02 6.576700e+02,2.797141e+02 6.606869e+02,2.717471e+02 C6.637037e+02,2.637800e+02 6.667205e+02,2.440146e+02 6.697374e+02,2.219516e+02 C6.727542e+02,1.998886e+02 6.757710e+02,1.671090e+02 6.787879e+02,1.393692e+02 C6.818047e+02,1.116294e+02 6.848215e+02,7.834414e+01 6.878384e+02,5.551300e+01 C6.908552e+02,3.268185e+01 6.938721e+02,1.159253e+01 6.968889e+02,2.382294e+00 C6.999057e+02,-6.827941e+00 7.029226e+02,-7.673691e+00 7.059394e+02,2.515819e-01 C7.089562e+02,8.176855e+00 7.119731e+02,2.789741e+01 7.149899e+02,4.993393e+01 C7.180067e+02,7.197046e+01 7.210236e+02,1.047320e+02 7.240404e+02,1.324707e+02 C7.270572e+02,1.602094e+02 7.300741e+02,1.935103e+02 7.330909e+02,2.163662e+02 C7.361077e+02,2.392221e+02 7.391246e+02,2.603547e+02 7.421414e+02,2.696061e+02 C7.451582e+02,2.788574e+02 7.481751e+02,2.797577e+02 7.511919e+02,2.718742e+02 C7.542088e+02,2.639907e+02 7.572256e+02,2.443151e+02 7.602424e+02,2.223051e+02 C7.632593e+02,2.002951e+02 7.662761e+02,1.675517e+02 7.692929e+02,1.398141e+02 C7.723098e+02,1.120766e+02 7.753266e+02,7.876021e+01 7.783434e+02,5.587964e+01 C7.813603e+02,3.299906e+01 7.843771e+02,1.182312e+01 7.873939e+02,2.530698e+00 C7.904108e+02,-6.761721e+00 7.934276e+02,-7.716574e+00 7.964444e+02,1.251203e-01 C7.994613e+02,7.966814e+00 8.024781e+02,2.759742e+01 8.054949e+02,4.958086e+01 C8.085118e+02,7.156431e+01 8.115286e+02,1.042894e+02 8.145455e+02,1.320258e+02 C8.175623e+02,1.597622e+02 8.205791e+02,1.930939e+02 8.235960e+02,2.159991e+02 C8.266128e+02,2.389043e+02 8.296296e+02,2.601235e+02 8.326465e+02,2.694570e+02 C8.356633e+02,2.787905e+02 8.386801e+02,2.797999e+02 8.416970e+02,2.720000e+02 C8.447138e+02,2.642001e+02 8.477306e+02,2.446146e+02 8.507475e+02,2.226577e+02 C8.537643e+02,2.007009e+02 8.567811e+02,1.679942e+02 8.597980e+02,1.402591e+02 C8.628148e+02,1.125240e+02 8.658316e+02,7.917684e+01 8.688485e+02,5.624706e+01 C8.718653e+02,3.331729e+01 8.748822e+02,1.205493e+01 8.778990e+02,2.680419e+00 C8.809158e+02,-6.694092e+00 8.839327e+02,-7.758038e+00 8.869495e+02,0.000000e+00 C8.899663e+02,7.758038e+00 8.944916e+02,4.102387e+01 8.960000e+02,4.922865e+01 \"/></g><g fill=\"none\" stroke=\"black\" stroke-width=\"2px\" stroke-linecap=\"round\" stroke-linejoin=\"round\"><rect vector-effect=\"non-scaling-stroke\" x=\"64\" y=\"64\" width=\"896\" height=\"272\"/><g fill=\"black\" font-family=\"sans-serif\" font-weight=\"bold\" text-anchor=\"middle\" font-size=\"18px\" font-style=\"normal\" dominant-baseline=\"middle\"><text stroke=\"none\" vector-effect=\"non-scaling-stroke\" x=\"512\" y=\"32\" dominant-baseline=\"middle\">Animated Sine</text></g></g></svg>"
       ]
      },
      "metadata": {},
@@ -1027,6 +1037,97 @@
   },
   {
    "cell_type": "markdown",
+   "id": "dcccb4f1-a9b6-40e4-9d57-013e7103c4a9",
+   "metadata": {},
+   "source": [
+    "## Init Functions\n",
+    "\n",
+    "Since there is always only one definition per function name, it's not possible for\n",
+    "each cell to have it's own init() function.\n",
+    "Instead GoNB converts any function named `func init_something()` to `init()` before\n",
+    "compiling and executing the cells. \n",
+    "This way each cell can create its own `func init_...()` and have it called at every\n",
+    "cell execution.\n",
+    "\n",
+    "Example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "03452fc9-f43c-4fb1-b1ce-50df961a214d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "init_a\n",
+      "main\n"
+     ]
+    }
+   ],
+   "source": [
+    "func init_a() {\n",
+    "    fmt.Println(\"init_a\")\n",
+    "}\n",
+    "%%\n",
+    "fmt.Println(\"main\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "13a230fd-1179-4ec3-b24c-4f89e0913920",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "init_a\n",
+      "init_b\n",
+      "main\n"
+     ]
+    }
+   ],
+   "source": [
+    "func init_b() {\n",
+    "    fmt.Println(\"init_b\")\n",
+    "}\n",
+    "%%\n",
+    "fmt.Println(\"main\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00882646-c238-48e1-a2ee-18944d9fd302",
+   "metadata": {},
+   "source": [
+    "Now, we don't want to have `init_a` and `init_b` on all of our cells below. So we remove those definitions -- see how to manage memorized definitions using `%help`, in the \"Managing Memorized Definitions\" section, it's displayed at the end of the tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "0b8683aa-0bf0-4058-8992-1c5b9e2c2b0c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      ". removed func init_a\n",
+      ". removed func init_b\n"
+     ]
+    }
+   ],
+   "source": [
+    "%rm init_a init_b"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "0037e1db-61a2-4fd8-bc6f-d8a45eda5b5d",
    "metadata": {},
    "source": [
@@ -1043,7 +1144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 21,
    "id": "4e2e9992-3a74-4825-87d8-773bdc30b05f",
    "metadata": {
     "tags": []
@@ -1079,7 +1180,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 22,
    "id": "27c7aaad-b0d3-46f0-b1f6-dc66722fe5bd",
    "metadata": {
     "tags": []
@@ -1118,7 +1219,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 23,
    "id": "724e33f4-c5fa-4fbe-9d90-e411369a74f3",
    "metadata": {},
    "outputs": [
@@ -1128,10 +1229,10 @@
      "text": [
       "go version go1.20.5 linux/amd64\n",
       "/home/janpf/Projects/gonb/examples\n",
-      "total 428\n",
+      "total 364\n",
       "-rw-r--r-- 1 janpf janpf 158378 Mar  8 07:18 experimental.ipynb\n",
       "-rwxr-xr-x 1 janpf janpf  87160 May 22 11:29 google_colab_demo.ipynb\n",
-      "-rw-r--r-- 1 janpf janpf 185777 Jul 20 09:14 tutorial.ipynb\n"
+      "-rw-r--r-- 1 janpf janpf 122266 Aug  8 09:16 tutorial.ipynb\n"
      ]
     }
    ],
@@ -1155,7 +1256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 24,
    "id": "be207993-219d-4a7f-a130-5111971fb867",
    "metadata": {},
    "outputs": [
@@ -1163,14 +1264,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/tmp/gonb_036046a6\n",
-      "total 9296\n",
-      "-rw-r--r-- 1 janpf janpf    1202 Jul 20 09:15 go.mod\n",
-      "-rwxr-xr-x 1 janpf janpf 9491670 Jul 20 09:15 gonb_036046a6\n",
-      "prw------- 1 janpf janpf       0 Jul 20 09:15 gonb_pipe_3304903318\n",
-      "srwxr-xr-x 1 janpf janpf       0 Jul 20 09:14 gopls_socket\n",
-      "-rw-r--r-- 1 janpf janpf   10229 Jul 20 09:15 go.sum\n",
-      "-rw-r--r-- 1 janpf janpf    4819 Jul 20 09:15 main.go\n"
+      "/tmp/gonb_f47c498f\n",
+      "total 8948\n",
+      "-rw-r--r-- 1 janpf janpf    1202 Aug  8 09:16 go.mod\n",
+      "-rwxr-xr-x 1 janpf janpf 9135352 Aug  8 09:16 gonb_f47c498f\n",
+      "prw------- 1 janpf janpf       0 Aug  8 09:16 gonb_pipe_2553551255\n",
+      "srwxr-xr-x 1 janpf janpf       0 Aug  8 09:15 gopls_socket\n",
+      "-rw-r--r-- 1 janpf janpf   10229 Aug  8 09:16 go.sum\n",
+      "-rw-r--r-- 1 janpf janpf    4708 Aug  8 09:16 main.go\n"
      ]
     }
    ],
@@ -1190,7 +1291,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 25,
    "id": "8688859a-ec3b-4e54-99b4-abbd8542091d",
    "metadata": {},
    "outputs": [
@@ -1264,7 +1365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 26,
    "id": "3391f12e-131b-45b8-b270-6ba06abaac8c",
    "metadata": {
     "tags": []
@@ -1274,7 +1375,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "module gonb_036046a6\n",
+      "module gonb_f47c498f\n",
       "\n",
       "go 1.20\n",
       "\n",
@@ -1282,9 +1383,9 @@
       "\tgithub.com/ajstarks/svgo v0.0.0-20211024235047-1546f124cd8b\n",
       "\tgithub.com/benc-uk/gofract v0.0.0-20230120162050-a6f644f92fd6\n",
       "\tgithub.com/erkkah/margaid v0.1.1-0.20230128143048-d60b2efd2f5a\n",
-      "\tgithub.com/janpfeifer/gonb v0.7.3\n",
+      "\tgithub.com/janpfeifer/gonb v0.7.6\n",
       "\tgithub.com/schollz/progressbar/v3 v3.13.1\n",
-      "\tgolang.org/x/exp v0.0.0-20230713183714-613f0c0eb8a1\n",
+      "\tgolang.org/x/exp v0.0.0-20230807204917-050eac23e9de\n",
       "\tgonum.org/v1/plot v0.13.0\n",
       ")\n",
       "\n",
@@ -1330,7 +1431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 27,
    "id": "45cf4a12-4b93-480f-bd83-2d375e7a475d",
    "metadata": {
     "tags": []
@@ -1340,7 +1441,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t- replace rule for module \"github.com/janpfeifer/gonb\" to local directory \"/home/janpf/Projects/gonb\" already exists."
+      "\t- Replace rule for module \"github.com/janpfeifer/gonb\" to local directory \"/home/janpf/Projects/gonb\" already exists.\n"
      ]
     }
    ],
@@ -1376,7 +1477,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 28,
    "id": "f6d836c1-3dfd-41a0-b097-b157f33289a8",
    "metadata": {
     "tags": []
@@ -1459,12 +1560,12 @@
       "\t%%\n",
       "\tfmt.Printf(\"Hello world!\\n\")\n",
       "\n",
+      "Init Functions -- \"func init()\":\n",
       "\n",
-      "- \"init()\" functions: since there is always only one definition per function name, \n",
-      "  it's not possible for each cell to have it's own init() function. Instead GoNB\n",
-      "  converts any function named \"init_<my_stuff>()\" to \"init()\" before compiling and\n",
-      "  executing. This way each cell can create its own \"init_...()\" and have it called\n",
-      "  at every cell execution.\n",
+      "  Since there is always only one definition per function name, it's not possible for\n",
+      "  each cell to have it's own init() function. Instead GoNB converts any function named \n",
+      "  \"init_<my_stuff>()\" to \"init()\" before compiling and executing. This way each cell can\n",
+      "  create its own \"init_...()\" and have it called at every cell execution.\n",
       "\n",
       "Special non-Go commands: \n",
       "\n",
@@ -1487,7 +1588,7 @@
       "- \"%with_password\": will prompt for a password passed to the next shell command.\n",
       "  Do this is if your next shell command requires a password.\n",
       "\n",
-      "Managing memorized definitions;\n",
+      "Managing Memorized Definitions:\n",
       "\n",
       "- \"%list\" (or \"%ls\"): Lists all memorized definitions (imports, constants, types, variables and\n",
       "  functions) that are carried from one cell to another.\n",

--- a/goexec/composer.go
+++ b/goexec/composer.go
@@ -187,9 +187,7 @@ func (d *Declarations) RenderFunctions(w *WriterWithCursor, fileToCellIdAndLine 
 		if funcDecl.HasCursor() {
 			cursor = w.CursorPlusDelta(funcDecl.Cursor)
 		}
-		if strings.HasPrefix(key, "init_") {
-			// TODO: this will not work if there is a comment before the function
-			//       which also has the string key. We need something more sophisticated.
+		if strings.HasPrefix(key, InitFunctionPrefix) {
 			def = strings.Replace(def, key, "init", 1)
 		}
 		w.Writef("%s\n\n", def)
@@ -421,7 +419,7 @@ func (s *State) createAlternativeFileFromDecls(decls *Declarations) (err error) 
 
 // createGoContentsFromDecls writes to the given file all the declarations.
 //
-// mainDecl is optional, and if not given no `main` function is created.
+// mainDecl is optional, and if not given, no `main` function is created.
 //
 // It returns the cursor position in the file as well as a mapping from the file lines to the original cell ids and lines.
 func (s *State) createGoContentsFromDecls(writer io.Writer, decls *Declarations, mainDecl *Function) (cursor Cursor, fileToCellIdAndLine []CellIdAndLine, err error) {

--- a/goexec/execcode.go
+++ b/goexec/execcode.go
@@ -33,7 +33,8 @@ func (s *State) ExecuteCell(msg kernel.Message, cellId int, lines []string, skip
 		return errors.WithMessagef(err, "in goexec.ExecuteCell()")
 	}
 
-	// Exec `goimports` (or the code that implements it)
+	// Exec `goimports` (or the code that implements it) -- it updates `updatedDecls` with
+	// the new imports, if there are any.
 	_, fileToCellIdAndLine, err = s.GoImports(msg, updatedDecls, mainDecl, fileToCellIdAndLine)
 	if err != nil {
 		return errors.WithMessagef(err, "goimports failed")
@@ -122,6 +123,7 @@ can install it from the notebook with:
 	// Parse declarations in created `main.go` file.
 	var newDecls *Declarations
 	newDecls, err = s.parseFromMainGo(msg, -1, NoCursor, nil)
+	newDecls.DropFuncInit() // These may be generated, we don't want to memorize these.
 	if err != nil {
 		return
 	}

--- a/goexec/goexec.go
+++ b/goexec/goexec.go
@@ -18,7 +18,14 @@ import (
 )
 
 const (
+	// GonbTempDirEnvName is the name of the environment variable that is set with
+	// the temporary directory used to compile user's Go code.
+	// It can be used by the executed Go code or by the bash scripts (started with `!`).
 	GonbTempDirEnvName = "GONB_TMP_DIR"
+
+	// InitFunctionPrefix -- functions named with this prefix will be rendered as
+	// a separate `func init()`.
+	InitFunctionPrefix = "init_"
 )
 
 // State holds information about Go code execution for this kernel. It's a singleton (for now).
@@ -215,6 +222,14 @@ func (d *Declarations) ClearCursor() {
 func clearCursor[K comparable, V interface{ ClearCursor() }](data map[K]V) {
 	for _, v := range data {
 		v.ClearCursor()
+	}
+}
+
+// DropFuncInit drops declarations of `func init()`: the parser generates this for the `func init_*`,
+// and it shouldn't be considered new declarations if reading from generated code.
+func (d *Declarations) DropFuncInit() {
+	if _, found := d.Functions["init"]; found {
+		delete(d.Functions, "init")
 	}
 }
 

--- a/goexec/parser.go
+++ b/goexec/parser.go
@@ -378,6 +378,10 @@ func (pi *parseInfo) ParseTypeEntry(decls *Declarations, typedDecl *ast.GenDecl)
 //
 // skipLines are lines that should not be considered as Go code. Typically, these are the special
 // commands (like `%%`, `%args`, `%reset`, or bash lines starting with `!`).
+//
+// Note: `func init_*()` functions are rendered as `func init()`: that means if one is parsing an
+// already generated code, the original `func init_*()` will be missing (which is usually ok), but
+// there will be a newly generated `func init()` that shouldn't be memorized. See
 func (s *State) parseLinesAndComposeMain(msg kernel.Message, cellId int, lines []string, skipLines Set[int], cursorInCell Cursor) (
 	updatedDecls *Declarations, mainDecl *Function, cursorInFile Cursor, fileToCellIdAndLine []CellIdAndLine, err error) {
 	cursorInFile = NoCursor

--- a/goexec/tracking.go
+++ b/goexec/tracking.go
@@ -520,7 +520,7 @@ func (s *State) GoWorkFix(msg kernel.Message) (err error) {
 			if replace.New.Path == p {
 				// The correct "replace" rule already exists.
 				err = kernel.PublishWriteStream(msg, kernel.StreamStdout,
-					fmt.Sprintf("\t- replace rule for module %q to local directory %q already exists.",
+					fmt.Sprintf("\t- Replace rule for module %q to local directory %q already exists.\n",
 						mod, p))
 				if err != nil {
 					return
@@ -531,7 +531,7 @@ func (s *State) GoWorkFix(msg kernel.Message) (err error) {
 			// Update previous "replace" rule.
 			err = kernel.PublishWriteStream(msg, kernel.StreamStderr,
 				fmt.Sprintf(
-					"WARNING: replace rule for module %q mapping to %q, updated to `go.work` location %q",
+					"\t- WARNING: replace rule for module %q mapping to %q, updated to `go.work` location %q\n",
 					mod, replace.New.Path, p))
 			if err != nil {
 				return
@@ -543,7 +543,7 @@ func (s *State) GoWorkFix(msg kernel.Message) (err error) {
 			}
 		} else {
 			err = kernel.PublishWriteStream(msg, kernel.StreamStdout,
-				fmt.Sprintf("\t- added replace rule for module %q to local directory %q.",
+				fmt.Sprintf("\t- Added replace rule for module %q to local directory %q.\n",
 					mod, p))
 		}
 		err = modFile.AddReplace(mod, "", p, "")

--- a/gonbui/gonbui.go
+++ b/gonbui/gonbui.go
@@ -87,10 +87,22 @@ func DisplayHTML(html string) {
 	})
 }
 
-// UpdateHTML displays the given HTML in the notebook on an output block with the given `id`: the block is created
-// automatically the first time this function is called, and simply updated thereafter.
+// DisplayMarkdown will display the given markdown content in the notebook, as the output of the cell being executed.
+func DisplayMarkdown(markdown string) {
+	if !IsNotebook {
+		return
+	}
+	sendData(&protocol.DisplayData{
+		Data: map[protocol.MIMEType]any{protocol.MIMETextMarkdown: markdown},
+	})
+}
+
+// UpdateHTML displays the given HTML in the notebook on an output block with the given `id`:
+// the block identified by 'id' is created automatically the first time this function is
+// called, and simply updated thereafter.
 //
-// The contents of these cells are considered transient, and intended to live only during a kernel session.
+// The contents of these output blocks are considered transient, and intended to live
+// only during a kernel session.
 //
 // Usage example:
 //
@@ -114,13 +126,31 @@ func UpdateHTML(id, html string) {
 	})
 }
 
-// UniqueID returns a unique id that can be used for UpdateHTML. Should be generated once per display block
-// the program wants to update.
+// UniqueID returns a unique id that can be used for UpdateHTML.
+// It should be generated once per display block the program wants to update.
 func UniqueID() string {
 	uuid, _ := uuid.NewV7()
 	uuidStr := uuid.String()
 	uid := uuidStr[len(uuidStr)-8:]
 	return fmt.Sprintf("gonb_id_%s", uid)
+}
+
+// UpdateMarkdown updates the contents of the output identified by id:
+// the block identified by 'id' is created automatically the first time this function is
+// called, and simply updated thereafter.
+//
+// The contents of these output blocks are considered transient, and intended to live only
+// during a kernel session.
+//
+// See example in UpdateHTML, just instead this used Markdown content.
+func UpdateMarkdown(id, markdown string) {
+	if !IsNotebook {
+		return
+	}
+	sendData(&protocol.DisplayData{
+		Data:      map[protocol.MIMEType]any{protocol.MIMETextMarkdown: markdown},
+		DisplayID: id,
+	})
 }
 
 // DisplayPNG displays the given PNG, given as raw bytes.

--- a/kernel/messages.go
+++ b/kernel/messages.go
@@ -380,6 +380,20 @@ func PublishDisplayDataWithHTML(msg Message, html string) error {
 	return PublishDisplayData(msg, msgData)
 }
 
+// PublishDisplayDataWithMarkdown is a shortcut to PublishDisplayData for markdown content.
+func PublishDisplayDataWithMarkdown(msg Message, markdown string) error {
+	msgData := Data{
+		Data:      make(MIMEMap, 1),
+		Metadata:  make(MIMEMap),
+		Transient: make(MIMEMap),
+	}
+	msgData.Data[string(protocol.MIMETextMarkdown)] = markdown
+	if klog.V(1).Enabled() {
+		logDisplayData(msgData.Data)
+	}
+	return PublishDisplayData(msg, msgData)
+}
+
 const (
 	// StreamStdout defines the stream name for standard out on the front-end. It
 	// is used in `PublishWriteStream` to specify the stream to write to.

--- a/specialcmd/help.md
+++ b/specialcmd/help.md
@@ -1,0 +1,127 @@
+## GoNB Help Page
+
+**GoNB** is a Go kernel that compiles and executes on-the-fly Go code.
+
+When executing a cell, **GoNB** will save the cell contents (except non-Go commands see
+below) into a `main.go` file, compile and execute it.
+
+It also saves any global declarations (imports, functions, types, variables, constants)
+and reuse them at the next cell execution -- so you can define a function in one
+cell, and reuse in the next one. Just the `func main()` is not reused.
+
+A `hello world` example would look like:
+
+```go
+func main() {
+    fmt.Printf(`Hello world!\n`);
+}
+
+```
+
+But to avoid having to type `func main()` all the time, you can use `%%` and everything
+after is wrapped inside a `func main() { ... }`. 
+So our revised `hello world` looks like:
+
+```go
+%%
+fmt.Printf(`Hello world!\n`)
+
+```
+
+### Init Functions -- `func init()`
+
+Since there is always only one definition per function name, it's not possible for
+each cell to have its own init() function. 
+Instead, **GoNB** converts any function named `init_something()` to `init()` before 
+compiling and executing. 
+This way each cell can create its own `init_...()` and have it called at every cell execution.
+
+### Special non-Go Commands
+
+- `%%` or `%main`: Marks the lines as follows to be wrapped in a `func main() {...}` during
+  execution. A shortcut to quickly execute code. It also automatically includes `flag.Parse()`
+  as the very first statement. Anything `%%` or `%main` are taken as arguments
+  to be passed to the program -- it resets previous values given by `%args`.
+- `%args`: Sets arguments to be passed when executing the Go code. This allows one to
+  use flags as a normal program. Notice that if a value after `%%` or `%main` is given, it will
+  overwrite the values here.
+- `%autoget` and `%noautoget`: Default is `%autoget`, which automatically does `go get` for
+  packages not yet available.
+- `%cd [<directory>]`: Change current directory of the Go kernel, and the directory from where
+  the cells are executed. If no directory is given it reports the current directory.
+- `%env VAR value`: Sets the environment variable VAR to the given value. These variables
+  will be available both for Go code as well as for shell scripts.
+- `%with_inputs`: will prompt for inputs for the next shell command. Use this if
+  the next shell command (`!`) you execute reads the stdin. Jupyter will require
+  you to enter one last value after the shell script executes.
+- `%with_password`: will prompt for a password passed to the next shell command.
+  Do this is if your next shell command requires a password.
+
+### Managing Memorized Definitions
+
+- `%list` (or `%ls`): Lists all memorized definitions (imports, constants, types, variables and
+  functions) that are carried from one cell to another.
+- `%remove <definitions>` (or `%rm <definitions>`): Removes (forgets) given definition(s). Use as key the
+  value(s) listed with `%ls`.
+- `%reset [go.mod]` clears all memorized definitions (imports, constants, types, functions, etc.)
+  as well as re-initializes the `go.mod` file. 
+  If the optional `go.mod` parameter is given, it will re-initialize only the `go.mod` file -- 
+  useful when testing different set up of versions of libraries.
+
+### Executing Shell Commands
+
+- `!<shell_cmd>`: executes the given command on a new shell. It makes it easy to run
+  commands on the kernels box, for instance to install requirements, or quickly
+  check contents of directories or files. Lines ending in `\` are continued on
+  the next line -- so multi-line commands can be entered. But each command is
+  executed in its own shell, that is, variables and state is not carried over.
+- `!*<shell_cmd>`: same as `!<shell_cmd>` except it first changes directory to
+  the temporary directory used to compile the go code -- the latest execution
+  is always saved in the file `main.go`. It's also where the `go.mod` file for
+  the notebook is created and maintained. Useful for manipulating `go.mod`,
+  for instance to get a package from some specific version, something
+  like `!*go get github.com/my/package@v3`.
+
+### Tracking of Go Files In Development:
+
+A convenient way to develop programs or libraries in **GoNB** is to use replace
+rules in **GoNB**'s `go.mod` to your program or library being developed and test
+your program from **GoNB** -- see the 
+[Tutorial]((https://github.com/janpfeifer/gonb/blob/main/examples/tutorial.ipynb))'s
+section "Developing Go libraries with a notebook" for different ways of achieving this.
+
+To manipulate the list of files tracked for changes:
+
+- `%track [file_or_directory]`: add file or directory to list of tracked files,
+  which are monitored by **GoNB** (and 'gopls') for auto-complete or contextual help.
+  If no file is given, it lists the currently tracked files.
+- `%untrack [file_or_directory][...]`: remove file or directory from list of tracked files.
+  If suffixed with `...` it will remove all files prefixed with the string given (without the
+  `...`). If no file is given, it lists the currently tracked files.
+
+### Environment Variables
+
+For convenience, **GoNB** defines the following environment variables -- available for the shell
+scripts (`!` and `!*`) and for the Go cells:
+
+- `GONB_DIR`: the directory where commands are executed from. This can be changed with `%cd`.
+- `GONB_TMP_DIR`: the directory where the temporary Go code, with the cell code, is stored
+  and compiled. This is the directory where `!*` scripts are executed. It only changes when a kernel
+  is restarted, and a new temporary directory is created.
+- `GONB_PIPE`: is the _named pipe_ directory used to communicate rich content (HTML, images)
+  to the kernel. Only available for _Go_ cells, and a new one is created at every execution.
+  This is used by the `**GoNB**ui`` functions described above, and doesn't need to be accessed directly.
+
+### Other
+
+- `%goworkfix`: work around 'go get' inability to handle 'go.work' files. If you are
+  using 'go.work' file to point to locally modified modules, consider using this. It creates
+  'go mod edit --replace' rules to point to the modules pointed to the 'use' rules in 'go.work'
+  file. It overwrites/updates 'replace' rules for those modules, if they already exist. See tutorial
+  for an example.
+
+### Links
+
+- [github.com/janpfeifer/gonb](https://github.com/janpfeifer/gonb) - GitHub page.
+- [Tutorial](https://github.com/janpfeifer/gonb/blob/main/examples/tutorial.ipynb).
+- [go.dev](https://pkg.go.dev/github.com/janpfeifer/gonb) package reference.

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -44,12 +44,12 @@ after is wrapped inside a "func main() { ... }". So our revised "hello world" lo
 	%%
 	fmt.Printf("Hello world!\n")
 
+Init Functions -- "func init()":
 
-- "init()" functions: since there is always only one definition per function name, 
-  it's not possible for each cell to have it's own init() function. Instead GoNB
-  converts any function named "init_<my_stuff>()" to "init()" before compiling and
-  executing. This way each cell can create its own "init_...()" and have it called
-  at every cell execution.
+  Since there is always only one definition per function name, it's not possible for
+  each cell to have it's own init() function. Instead GoNB converts any function named 
+  "init_<my_stuff>()" to "init()" before compiling and executing. This way each cell can
+  create its own "init_...()" and have it called at every cell execution.
 
 Special non-Go commands: 
 

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -72,7 +72,7 @@ Special non-Go commands:
 - "%with_password": will prompt for a password passed to the next shell command.
   Do this is if your next shell command requires a password.
 
-Managing memorized definitions;
+Managing Memorized Definitions:
 
 - "%list" (or "%ls"): Lists all memorized definitions (imports, constants, types, variables and
   functions) that are carried from one cell to another.

--- a/specialcmd/specialcmd.go
+++ b/specialcmd/specialcmd.go
@@ -8,14 +8,16 @@
 package specialcmd
 
 import (
+	_ "embed"
 	"fmt"
+	"os"
+
 	. "github.com/janpfeifer/gonb/common"
 	"github.com/janpfeifer/gonb/goexec"
 	"github.com/janpfeifer/gonb/gonbui/protocol"
 	"github.com/janpfeifer/gonb/kernel"
 	"github.com/pkg/errors"
 	"k8s.io/klog/v2"
-	"os"
 )
 
 // MillisecondsWaitForInput is the wait time for a bash script (started with `!` or `!*`
@@ -23,110 +25,8 @@ import (
 // input is prompted to the Jupyter Notebook.
 const MillisecondsWaitForInput = 200
 
-const HelpMessage = `GoNB is a Go kernel that compiles and executed on-the-fly Go code. 
-
-When executing a cell, *GoNB* will save the cell contents (except non-Go commands see
-below) into a "main.go" file, compile and execute it.
-
-It also saves any global declarations (imports, functions, types, variables, constants)
-and reuse them at the next cell execution -- so you can define a function in one
-cell, and reuse in the next one. Just the "func main()" is not reused.
-
-A "hello world" example would look like:
-
-	func main() {
-		fmt.Printf("Hello world!\n");
-	}
-
-But to avoid having to type "func main()" all the time, you can use "%%" and everything
-after is wrapped inside a "func main() { ... }". So our revised "hello world" looks like:
-
-	%%
-	fmt.Printf("Hello world!\n")
-
-Init Functions -- "func init()":
-
-  Since there is always only one definition per function name, it's not possible for
-  each cell to have it's own init() function. Instead GoNB converts any function named 
-  "init_<my_stuff>()" to "init()" before compiling and executing. This way each cell can
-  create its own "init_...()" and have it called at every cell execution.
-
-Special non-Go commands: 
-
-- "%%" or "%main": Marks the lines as follows to be wrapped in a "func main() {...}" during 
-  execution. A shortcut to quickly execute code. It also automatically includes "flag.Parse()"
-  as the very first statement. Anything "%%" or "%main" are taken as arguments
-  to be passed to the program -- it resets previous values given by "%args".
-- "%args": Sets arguments to be passed when executing the Go code. This allows one to
-  use flags as a normal program. Notice that if a value after "%%" or "%main" is given, it will
-  overwrite the values here.
-- "%autoget" and "%noautoget": Default is "%autoget", which automatically does "go get" for
-  packages not yet available.
-- "%cd [<directory>]": Change current directory of the Go kernel, and the directory from where
-  the cells are executed. If no directory is given it reports the current directory.
-- "%env VAR value": Sets the environment variable VAR to the given value. These variables
-  will be available both for Go code as well as for shell scripts.
-- "%with_inputs": will prompt for inputs for the next shell command. Use this if
-  the next shell command ("!") you execute reads the stdin. Jupyter will require
-  you to enter one last value after the shell script executes.
-- "%with_password": will prompt for a password passed to the next shell command.
-  Do this is if your next shell command requires a password.
-
-Managing Memorized Definitions:
-
-- "%list" (or "%ls"): Lists all memorized definitions (imports, constants, types, variables and
-  functions) that are carried from one cell to another.
-- "%remove <definitions>" (or "%rm <definitions>"): Removes (forgets) given definition(s). Use as key the
-  value(s) listed with "%ls".
-- "%reset [go.mod]" clears all memorized definitions (imports, constants, types, functions, etc.)
-  as well as re-initializes the go.mod file. If the optional "go.mod" parameter is given, it 
-  will re-initialize only the go.mod file -- useful when testing different set up of versions 
-  of libraries.
-
-Executing shell commands:
-
-- "!<shell_cmd>": executes the given command on a new shell. It makes it easy to run
-  commands on the kernels box, for instance to install requirements, or quickly
-  check contents of directories or files. Lines ending in "\" are continued on
-  the next line -- so multi-line commands can be entered. But each command is
-  executed in its own shell, that is, variables and state is not carried over.
-- "!*<shell_cmd>": same as "!<shell_cmd>" except it first changes directory to
-  the temporary directory used to compile the go code -- the latest execution
-  is always saved in the file "main.go". It's also where the "go.mod" file for
-  the notebook is created and maintained. Useful for manipulating "go.mod",
-  for instance to get a package from some specific version, something 
-  like "!*go get github.com/my/package@v3".
-
-Tracking of Go files being developed:
-
-- "%track [file_or_directory]": add file or directory to list of tracked files,
-  which are monitored by GoNB (and 'gopls') for auto-complete or contextual help.
-  If no file is given, it lists the currently tracked files.
-- "%untrack [file_or_directory][...]": remove file or directory from list of tracked files.
-  If suffixed with "..." it will remove all files prefixed with the string given (without the
-  "..."). If no file is given, it lists the currently tracked files. 
-
-Environment Variables:
-
-For convenience, GoNB defines the following environment variables -- available for the shell 
-scripts ("! and "!*") and for the Go cells:
-
-- "GONB_DIR": the directory where commands are executed from. This can be changed with "%cd".
-- "GONB_TMP_DIR": the directory where the temporary Go code, with the cell code, is stored 
-  and compiled. This is the directory where "!*" scripts are executed. It only changes when a kernel
-  is restarted, and a new temporary directory is created.
-- "GONB_PIPE": is the _named pipe_ directory used to communicate rich content (HTML, images)
-  to the kernel. Only available for _Go_ cells, and a new one is created at every execution.
-  This is used by the "gonbui"" functions described above, and doesn't need to be accessed directly.
-
-Other:
-
-- "%goworkfix": work around 'go get' inability to handle 'go.work' files. If you are
-  using 'go.work' file to point to locally modified modules, consider using this. It creates
-  'go mod edit --replace' rules to point to the modules pointed to the 'use' rules in 'go.work'
-  file. It overwrites/updates 'replace' rules for those modules, if they already exist. See tutorial
-  for an example.
-`
+//go:embed help.md
+var HelpMessage string
 
 // cellStatus holds temporary status for the execution of the current cell.
 type cellStatus struct {
@@ -264,7 +164,11 @@ func execInternal(msg kernel.Message, goExec *goexec.State, cmdStr string, statu
 	case "noautoget":
 		goExec.AutoGet = false
 	case "help":
-		_ = kernel.PublishWriteStream(msg, kernel.StreamStdout, HelpMessage)
+		//_ = kernel.PublishWriteStream(msg, kernel.StreamStdout, HelpMessage)
+		err := kernel.PublishDisplayDataWithMarkdown(msg, HelpMessage)
+		if err != nil {
+			klog.Errorf("Failed publishing %help contents: %+v", err)
+		}
 
 		// Definitions management.
 	case "reset":


### PR DESCRIPTION
* Added `DisplayMarkdown` and `UpdateMarkdown`.
* Changed `%help` to use markdown.
* `init_*` functions: 
  * Fixed duplicate rendering.
  * Added section about it in `tutorial.ipynb`
* Updated tutorial to used `%rm` to remove no longer wanted definitions.
