### PR TITLE
Bug fixes, and preparation for gonb-echarts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,7 @@
 * New `github.com/janpfeifer/gonb-echarts` to add support to [Apache ECharts](https://echarts.apache.org/en/index.html)
   using [github.com/go-echarts/go-echarts](https://github.com/go-echarts/go-echarts).
 * Updated documentation on VSCode limitation for Javascript.
+* Fixed bug in `dom.LoadScriptOrRequireJSModuleAndRun` where plotly source was hardcoded by mistake.
 
 ## 0.10.0, 2024/04/07 Improvements on Plotly, VSCode support, interrupt handling and several minor fixes. 
   

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,8 +2,12 @@
 
 ## Next
 
-* [`interrupt_mode`] set to `message`, as opposed to having a `SIGINT`. Works both in JupyterLab and VSCode.
-* Interrupt all cell executions at `shutdown_request`.
+* Interrupt and Shutdown:
+  * [`interrupt_mode`] set to `message`, as opposed to having a `SIGINT`. Works both in JupyterLab and VSCode.
+  * Interrupt all cell executions at `shutdown_request`.
+* New `github.com/janpfeifer/gonb-echarts` to add support to [Apache ECharts](https://echarts.apache.org/en/index.html)
+  using [github.com/go-echarts/go-echarts](https://github.com/go-echarts/go-echarts).
+* Updated documentation on VSCode limitation for Javascript.
 
 ## 0.10.0, 2024/04/07 Improvements on Plotly, VSCode support, interrupt handling and several minor fixes. 
   

--- a/gonbui/dom/script.go
+++ b/gonbui/dom/script.go
@@ -98,9 +98,10 @@ var loadOrRequireAndRunTmpl = template.Must(template.New("load_or_required_and_r
 	
     if (typeof requirejs === "function") {
         // Use RequireJS to load module.
+		let srcWithoutExtension = src.substring(0, src.lastIndexOf(".js"));
         requirejs.config({
             paths: {
-                '{{.ModuleName}}': 'https://cdn.plot.ly/plotly-2.29.1.min'
+                '{{.ModuleName}}': srcWithoutExtension
             }
         });
         require(['{{.ModuleName}}'], function({{.ModuleName}}) {

--- a/gonbui/javascript.go
+++ b/gonbui/javascript.go
@@ -14,6 +14,10 @@ import (
 //
 // If these are an issue, consider using TransientJavascript, which uses a transient area
 // to execute the Javascript, which is re-used for every execution.
+//
+// Note: `text/javascript` mime-type ([protocol.MIMETextJavascript]) is not supported by VSCode,
+// it's displayed as text. So using this won't work in VSCode. Consider instead using [DisplayHtml],
+// and wrapping the `js` string with `("<scrip>%s</script>", js)`.
 func ScriptJavascript(js string) {
 	if !IsNotebook {
 		return

--- a/internal/kernel/messages.go
+++ b/internal/kernel/messages.go
@@ -482,6 +482,9 @@ func PublishMarkdown(msg Message, markdown string) error {
 }
 
 // PublishJavascript is a shortcut to PublishData for javascript content to be executed.
+//
+// Note: `text/javascript` mime-type ([protocol.MIMETextJavascript]) is not supported by VSCode,
+// it's displayed as text. So using this won't work in VSCode.
 func PublishJavascript(msg Message, js string) error {
 	return PublishData(msg, Data{
 		Data:      MIMEMap{string(protocol.MIMETextJavascript): js},


### PR DESCRIPTION
* Interrupt and Shutdown:
  * [`interrupt_mode`] set to `message`, as opposed to having a `SIGINT`. Works both in JupyterLab and VSCode.
  * Interrupt all cell executions at `shutdown_request`.
* New `github.com/janpfeifer/gonb-echarts` to add support to [Apache ECharts](https://echarts.apache.org/en/index.html)
  using [github.com/go-echarts/go-echarts](https://github.com/go-echarts/go-echarts).
* Updated documentation on VSCode limitation for Javascript.
* Fixed bug in `dom.LoadScriptOrRequireJSModuleAndRun` where plotly source was hardcoded by mistake.
