### PR TITLE
Added GoNB version information

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # GoNB Changelog
 
+## Next
+
+* Added `%version`
+
 ## v0.10.6, 2024/10/16, Improved Docker, added `%capture`
 
 * Feature request #138

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Next
 
-* Added `%version`
+* Added `%version`, and environment variables `GONB_VERSION`, `GONB_GIT_COMMIT`.
+* Added `%help` info on missing environment variables.
 
 ## v0.10.6, 2024/10/16, Improved Docker, added `%capture`
 

--- a/gonbui/protocol/protocol.go
+++ b/gonbui/protocol/protocol.go
@@ -68,6 +68,12 @@ const (
 	// Notice that the Wasm program gets this value from a global variable automatically introduced in the Go code,
 	// see `%help`.
 	GONB_WASM_URL_ENV = "GONB_WASM_URL"
+
+	// GONB_VERSION of the build -- based on latest git tag.
+	GONB_VERSION = "GONB_VERSION"
+
+	// GONB_GIT_COMMIT hash for the build.
+	GONB_GIT_COMMIT = "GONB_GIT_COMMIT"
 )
 
 type MIMEType string

--- a/internal/specialcmd/help.md
+++ b/internal/specialcmd/help.md
@@ -70,6 +70,7 @@ This way each cell can create its own `init_...()` and have it called at every c
   it overwrites the file contents each time the cell is executed. Use `-a` instead to append to the file.
   It works only for the current cell. See also `%%writefile` to write files with a specific content.
   It doesn't work with `%wasm` cells.
+- `%version` prints out **GoNB**'s version.
 
 **Notes**: 
 
@@ -155,6 +156,15 @@ scripts (`!` and `!*`) and for the Go cells:
 - `GONB_PIPE`: is the _named pipe_ directory used to communicate rich content (HTML, images)
   to the kernel. Only available for _Go_ cells, and a new one is created at every execution.
   This is used by the `**GoNB**ui`` functions described above, and doesn't need to be accessed directly.
+- `GONB_VERSION`: Version of this *GoNB* build.
+- `GONB_GIT_COMMIT`: Git commit hash for this *GoNB* build -- notice it doesn't account for any modifications that
+  may have been made and not committed.
+- `GONB_JUPYTER_KERNEL_ID`: the unique id assigned by Jupyter to this kernel.
+  It's used to build some of the API paths to the JupyterServer.
+  If it's not set, GoNB was not able to parse it from the kernel file path.
+- `GONB_JUPYTER_ROOT`: the path to the Jupyter root directory, if GONB managed to read it (depends on the architecture).
+  This can be used to construct URLs to static file contents (images, javascript, etc.) served by Jupyter: 
+  one can use `src="/file/...<path under GONB_JUPYTER_ROOT>..."`.
 
 ### Widgets
 

--- a/internal/specialcmd/specialcmd.go
+++ b/internal/specialcmd/specialcmd.go
@@ -238,6 +238,17 @@ func execSpecialConfig(msg kernel.Message, goExec *goexec.State, cmdStr string, 
 		if err != nil {
 			klog.Errorf("Failed publishing help contents: %+v", err)
 		}
+	case "version":
+		gitHash := os.Getenv(protocol.GONB_GIT_COMMIT)
+		gitVersion := os.Getenv(protocol.GONB_VERSION)
+		gitCommitURL := fmt.Sprintf("https://github.com/janpfeifer/gonb/tree/%s", gitHash)
+		gitTagURL := fmt.Sprintf("https://github.com/janpfeifer/gonb/releases/tag/%s", gitVersion)
+
+		err := kernel.PublishMarkdown(msg, fmt.Sprintf(
+			"**GoNB** version [%s](%s) / Commit: [%s](%s)\n", gitVersion, gitTagURL, gitHash, gitCommitURL))
+		if err != nil {
+			klog.Errorf("Failed publishing version contents: %+v", err)
+		}
 
 	// Definitions management.
 	case "reset":

--- a/version.go
+++ b/version.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/janpfeifer/gonb/gonbui/protocol"
+	"os"
+)
+
+//go:generate bash -c "printf 'package main\nvar GitTag = \"%s\"\n' \"$(git describe --tags --abbrev=0)\" > versiontag.go"
+//go:generate bash -c "printf 'package main\nvar GitCommitHash = \"%s\"\n' \"$(git rev-parse HEAD)\" > versionhash.go"
+
+func must(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func init() {
+	must(os.Setenv(protocol.GONB_GIT_COMMIT, GitCommitHash))
+	must(os.Setenv(protocol.GONB_VERSION, GitTag))
+}

--- a/versionhash.go
+++ b/versionhash.go
@@ -1,2 +1,2 @@
 package main
-var GitCommitHash = "a3e905f994db16213060264623c82d240d2dcc73"
+var GitCommitHash = "0e5f587a077810d058202b76a127651a02bd4382"

--- a/versionhash.go
+++ b/versionhash.go
@@ -1,2 +1,2 @@
 package main
-var GitCommitHash = "ea8453363f53fb5feaa2120776ab6bc868012698"
+var GitCommitHash = "a3e905f994db16213060264623c82d240d2dcc73"

--- a/versionhash.go
+++ b/versionhash.go
@@ -1,0 +1,2 @@
+package main
+var GitCommitHash = "ea8453363f53fb5feaa2120776ab6bc868012698"

--- a/versiontag.go
+++ b/versiontag.go
@@ -1,0 +1,2 @@
+package main
+var GitTag = "v0.10.6"


### PR DESCRIPTION
* Added `%version`, and environment variables `GONB_VERSION`, `GONB_GIT_COMMIT`.
* Added `%help` info on missing environment variables.
