### PR TITLE
Include function comments in the generated code

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Added `%version`, and environment variables `GONB_VERSION`, `GONB_GIT_COMMIT`.
 * Added `%help` info on missing environment variables.
 * Added stack traces to protocol parsing errors.
+* Include function comments in the generated code. This makes tags like `//go:noinline` work. See #150
 
 ## v0.10.6, 2024/10/16, Improved Docker, added `%capture`
 

--- a/examples/tests/bash_script.ipynb
+++ b/examples/tests/bash_script.ipynb
@@ -34,7 +34,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/tmp/gonb_b9edd581\n"
+      "/tmp/gonb_d300f5a2\n"
      ]
     }
    ],
@@ -59,7 +59,7 @@
      "output_type": "stream",
      "text": [
       "/home/janpf/Projects/gonb/examples/tests\n",
-      "/tmp/gonb_b9edd581\n",
+      "/tmp/gonb_d300f5a2\n",
       "/home/janpf/Projects/gonb\n",
       "/home/janpf/Projects/gonb\n"
      ]
@@ -86,7 +86,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/capture.ipynb
+++ b/examples/tests/capture.ipynb
@@ -177,7 +177,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/comms.ipynb
+++ b/examples/tests/comms.ipynb
@@ -308,7 +308,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/dom.ipynb
+++ b/examples/tests/dom.ipynb
@@ -88,7 +88,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"dom.transient_div_32726297\"></div>"
+       "<div id=\"dom.transient_div_25f4f259\"></div>"
       ]
      },
      "metadata": {},
@@ -152,7 +152,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"dom.transient_div_5b814837\"></div>"
+       "<div id=\"dom.transient_div_759e5c9b\"></div>"
       ]
      },
      "metadata": {},
@@ -197,7 +197,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/functions.ipynb
+++ b/examples/tests/functions.ipynb
@@ -65,7 +65,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/goflags.ipynb
+++ b/examples/tests/goflags.ipynb
@@ -153,9 +153,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "gonb_0cdc700f/main.go:8:\tA\t\t100.0%\n",
-      "gonb_0cdc700f/main.go:12:\tB\t\t0.0%\n",
-      "gonb_0cdc700f/main.go:17:\tmain\t\t100.0%\n",
+      "gonb_ae2bcb52/main.go:8:\tA\t\t100.0%\n",
+      "gonb_ae2bcb52/main.go:12:\tB\t\t0.0%\n",
+      "gonb_ae2bcb52/main.go:17:\tmain\t\t100.0%\n",
       "total\t\t\t\t(statements)\t75.0%\n"
      ]
     }
@@ -238,7 +238,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "# gonb_0cdc700f\n",
+      "# gonb_ae2bcb52\n",
       "./main.go:10:6: can inline (*Point).ManhattanLen\n",
       "./main.go:16:12: inlining call to flag.Parse\n",
       "./main.go:18:27: inlining call to (*Point).ManhattanLen\n",
@@ -267,7 +267,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/gonbui.ipynb
+++ b/examples/tests/gonbui.ipynb
@@ -22,7 +22,7 @@
      "output_type": "stream",
      "text": [
       "%goflags=[\"--cover\" \"--covermode=set\"]\n",
-      "GOCOVERDIR=/tmp/gonb_test_coverage.fmW2jDEhWf\n"
+      "GOCOVERDIR=/tmp/gonb_nbtests_gocoverdir_4129479306\n"
      ]
     }
    ],
@@ -133,7 +133,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/gotest.ipynb
+++ b/examples/tests/gotest.ipynb
@@ -287,12 +287,12 @@
      "text": [
       "goos: linux\n",
       "goarch: amd64\n",
-      "pkg: gonb_a1453c14\n",
+      "pkg: gonb_74e427f6\n",
       "cpu: 12th Gen Intel(R) Core(TM) i9-12900K\n",
       "BenchmarkFibonacciA32\n",
-      "BenchmarkFibonacciA32-24    \t     169\t   7058908 ns/op\n",
+      "BenchmarkFibonacciA32-24    \t     178\t   6602828 ns/op\n",
       "BenchmarkFibonacciB32\n",
-      "BenchmarkFibonacciB32-24    \t285643864\t         3.680 ns/op\n",
+      "BenchmarkFibonacciB32-24    \t298555876\t         4.021 ns/op\n",
       "PASS\n",
       "coverage: [no statements]\n"
      ]
@@ -334,10 +334,10 @@
      "text": [
       "goos: linux\n",
       "goarch: amd64\n",
-      "pkg: gonb_a1453c14\n",
+      "pkg: gonb_74e427f6\n",
       "cpu: 12th Gen Intel(R) Core(TM) i9-12900K\n",
-      "BenchmarkFibonacciA32-24    \t     168\t   7082427 ns/op\n",
-      "BenchmarkFibonacciB32-24    \t308541147\t         3.901 ns/op\n",
+      "BenchmarkFibonacciA32-24    \t     180\t   6574007 ns/op\n",
+      "BenchmarkFibonacciB32-24    \t308328156\t         3.930 ns/op\n",
       "PASS\n",
       "coverage: [no statements]\n"
      ]
@@ -361,7 +361,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/gowork.ipynb
+++ b/examples/tests/gowork.ipynb
@@ -36,7 +36,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "/tmp/gonb_tests_gowork_IBSuBo7n"
+      "/tmp/gonb_tests_gowork_173uIYjd"
      ]
     }
    ],
@@ -64,7 +64,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Temporary test package: /tmp/gonb_tests_gowork_IBSuBo7n\n"
+      "Temporary test package: /tmp/gonb_tests_gowork_173uIYjd\n"
      ]
     }
    ],
@@ -136,7 +136,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\t- Added replace rule for module \"a.com/a/pkg\" to local directory \"/tmp/gonb_tests_gowork_IBSuBo7n\".\n"
+      "\t- Added replace rule for module \"a.com/a/pkg\" to local directory \"/tmp/gonb_tests_gowork_173uIYjd\".\n"
      ]
     }
    ],
@@ -155,9 +155,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "module gonb_05a80086\n",
+      "module gonb_b978d03f\n",
       "\n",
-      "go 1.23.2\n",
+      "go 1.23.5\n",
       "\n",
       "replace a.com/a/pkg => TMP_PKG\n"
      ]
@@ -186,7 +186,7 @@
       "text/html": [
        "<b>List of files/directories being tracked:</b>\n",
        "<ul>\n",
-       "<li>/tmp/gonb_tests_gowork_IBSuBo7n</li>\n",
+       "<li>/tmp/gonb_tests_gowork_173uIYjd</li>\n",
        "</ul>\n"
       ]
      },
@@ -208,9 +208,9 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "module gonb_05a80086\n",
+      "module gonb_b978d03f\n",
       "\n",
-      "go 1.23.2\n"
+      "go 1.23.5\n"
      ]
     }
    ],
@@ -280,7 +280,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/hello.ipynb
+++ b/examples/tests/hello.ipynb
@@ -99,7 +99,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/init.ipynb
+++ b/examples/tests/init.ipynb
@@ -156,7 +156,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/input_boxes.ipynb
+++ b/examples/tests/input_boxes.ipynb
@@ -22,7 +22,7 @@
      "output_type": "stream",
      "text": [
       "%goflags=[\"--cover\" \"--covermode=set\"]\n",
-      "GOCOVERDIR=/tmp/gonb_test_coverage.fmW2jDEhWf\n"
+      "GOCOVERDIR=/tmp/gonb_nbtests_gocoverdir_4129479306\n"
      ]
     }
    ],
@@ -196,7 +196,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/script.ipynb
+++ b/examples/tests/script.ipynb
@@ -105,7 +105,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/vartuple.ipynb
+++ b/examples/tests/vartuple.ipynb
@@ -45,7 +45,7 @@
       "text/html": [
        "<h4>Variables</h4>\n",
        "<ul>\n",
-       "<li><pre>_~653277</pre></li>\n",
+       "<li><pre>_~085390</pre></li>\n",
        "<li><pre>a</pre></li>\n",
        "<li><pre>c</pre></li>\n",
        "</ul>"
@@ -125,7 +125,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/widgets.ipynb
+++ b/examples/tests/widgets.ipynb
@@ -95,7 +95,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"dom.transient_div_7742ea2e\"></div>"
+       "<div id=\"dom.transient_div_540e2e0c\"></div>"
       ]
      },
      "metadata": {},
@@ -189,7 +189,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"dom.transient_div_b5a11420\"></div>"
+       "<div id=\"dom.transient_div_ddd43a51\"></div>"
       ]
      },
      "metadata": {},
@@ -304,7 +304,7 @@
     {
      "data": {
       "text/html": [
-       "<div id=\"dom.transient_div_07bc0111\"></div>"
+       "<div id=\"dom.transient_div_a322648e\"></div>"
       ]
      },
      "metadata": {},
@@ -416,7 +416,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/examples/tests/writefile.ipynb
+++ b/examples/tests/writefile.ipynb
@@ -10,7 +10,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Cell contents written to \"/tmp/gonb_nbtests_writefile_4201179243/poetry.txt\".\n"
+      "Cell contents written to \"/tmp/gonb_nbtests_writefile_2206415683/poetry.txt\".\n"
      ]
     }
    ],
@@ -32,7 +32,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Cell contents appended to \"/tmp/gonb_nbtests_writefile_4201179243/poetry.txt\".\n"
+      "Cell contents appended to \"/tmp/gonb_nbtests_writefile_2206415683/poetry.txt\".\n"
      ]
     }
    ],
@@ -55,7 +55,7 @@
    "name": "go",
    "nbconvert_exporter": "",
    "pygments_lexer": "",
-   "version": "go1.23.2"
+   "version": "go1.23.5"
   }
  },
  "nbformat": 4,

--- a/internal/goexec/execcode.go
+++ b/internal/goexec/execcode.go
@@ -168,9 +168,9 @@ func (s *State) CodePath() string {
 	return path.Join(s.TempDir, name)
 }
 
-// RemoveCode removes the code files (`main.go` or `main_test.go`).
-// Usually used just before creating creating a new version.
-func (s *State) RemoveCode() error {
+// RemoveGeneratedCode removes the code files (`main.go` or `main_test.go`).
+// Usually, it is used just before creating a new version.
+func (s *State) RemoveGeneratedCode() error {
 	for _, name := range [2]string{MainGo, MainTestGo} {
 		p := path.Join(s.TempDir, name)
 		err := os.Remove(p)

--- a/internal/goexec/goexec.go
+++ b/internal/goexec/goexec.go
@@ -408,6 +408,15 @@ type Function struct {
 	Name, Receiver string
 	Definition     string // Multi-line definition, includes comments preceding definition.
 
+	// Comments preceding the function, if any.
+	Comments *Comments
+}
+
+// Comments block definition: these are comments that precedes a declaration, like a function or variable.
+type Comments struct {
+	Cursor
+	CellLines
+	Lines []string
 }
 
 // Variable definition, parsed from a notebook cell.

--- a/internal/goexec/parser_test.go
+++ b/internal/goexec/parser_test.go
@@ -97,6 +97,7 @@ const (
 )
 
 // f calls g and adds 1.
+//go:noinline
 func f(x int) {
 	return g(x)+1  // g not defined in this file, but we still want to parse this.
 }
@@ -161,7 +162,9 @@ func TestState_Parse(t *testing.T) {
 	assert.Contains(t, s.Definitions.Functions, "Kg~Gain")
 	assert.Contains(t, s.Definitions.Functions, "N~Weight")
 	assert.Contains(t, s.Definitions.Functions, "main")
-	assert.ElementsMatch(t, []int{73, 73, 74, 75, 76, 77, -1, -1}, s.Definitions.Functions["main"].CellLines.Lines,
+	assert.ElementsMatch(t, []int{50, 51}, s.Definitions.Functions["f"].Comments.CellLines.Lines,
+		"Index to line numbers in original cell don't match.")
+	assert.ElementsMatch(t, []int{74, 74, 75, 76, 77, 78, -1, -1}, s.Definitions.Functions["main"].CellLines.Lines,
 		"Index to line numbers in original cell don't match.")
 
 	fmt.Printf("\ttest variables: %+v\n", s.Definitions.Variables)
@@ -251,11 +254,11 @@ func TestState_Parse(t *testing.T) {
 		{cellId, 29},
 		{cellId, 21},
 		{cellId, 22},
-		{cellId, 55},
+		{cellId, 56},
 		{cellId, 20},
 		{cellId, 20},
 		{cellId, 25},
-		{cellId, 71}, // var contents, _ = os.ReadFile("/tmp/a")
+		{cellId, 72}, // var contents, _ = os.ReadFile("/tmp/a")
 	}, fileToCellIdAndLine, "Line numbers in cell code don't match")
 
 	// Checks functions rendering.
@@ -269,6 +272,8 @@ func (k *Kg) Weight() N {
 
 func (n N) Weight() N { return n }
 
+// f calls g and adds 1.
+//go:noinline
 func f(x int) {
 	return g(x)+1  // g not defined in this file, but we still want to parse this.
 }
@@ -374,7 +379,7 @@ func TestCursorPositioning(t *testing.T) {
 		{Cursor{Line: 29, Col: 23}, `type XY struct { x, y f‸loat64 }`},
 
 		// Functions Lines:
-		{Cursor{Line: 59, Col: 12}, `func sum[T i‸nterface{int | float32 | float64}](a, b T) T {`},
+		{Cursor{Line: 60, Col: 12}, `func sum[T i‸nterface{int | float32 | float64}](a, b T) T {`},
 	}
 	for _, testLine := range testLines {
 		buf := bytes.NewBuffer(make([]byte, 0, 16384))


### PR DESCRIPTION
* Include function comments in the generated code. This makes tags like `//go:noinline` work. See #150
