### PR TITLE
Implemented basic Windows support (not WSL)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	go.lsp.dev/uri v0.3.0
 	golang.org/x/exp v0.0.0-20250106191152-7588d65b2ba8
 	golang.org/x/mod v0.26.0
+	golang.org/x/sys v0.29.0
 	k8s.io/klog/v2 v2.130.1
 )
 
@@ -42,7 +43,6 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
-	golang.org/x/sys v0.29.0 // indirect
 	golang.org/x/text v0.21.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/internal/goexec/cwd_others.go
+++ b/internal/goexec/cwd_others.go
@@ -1,4 +1,4 @@
-//go:build !linux
+//go:build !linux && !windows
 
 package goexec
 

--- a/internal/goexec/cwd_windows.go
+++ b/internal/goexec/cwd_windows.go
@@ -1,0 +1,171 @@
+//go:build windows
+
+package goexec
+
+import (
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+	"path/filepath"
+	"unsafe"
+)
+
+var (
+	modNtdll   = windows.NewLazySystemDLL("ntdll.dll")
+	modKernel32 = windows.NewLazySystemDLL("kernel32.dll")
+
+	procNtQueryInformationProcess = modNtdll.NewProc("NtQueryInformationProcess")
+	procQueryFullProcessImageNameW = modKernel32.NewProc("QueryFullProcessImageNameW")
+)
+
+const processBasicInformationClass = 0
+
+type processBasicInformation struct {
+	ExitStatus                   uintptr
+	PebBaseAddress               uintptr
+	AffinityMask                 uintptr
+	BasePriority                 uintptr
+	UniqueProcessID              uintptr
+	InheritedFromUniqueProcessID uintptr
+}
+
+type peb struct {
+	Reserved1         [2]byte
+	BeingDebugged     byte
+	Reserved2         byte
+	Reserved3         [2]uintptr
+	Ldr               uintptr
+	ProcessParameters uintptr
+	Reserved4         [3]uintptr
+	Reserved5         uintptr
+	Reserved6         [5]uintptr
+}
+
+type rtlUserProcessParameters struct {
+	Reserved1     [16]byte
+	Reserved2     [4]uintptr
+	ImagePathName struct {
+		Length    uint16
+		MaxLength uint16
+		Buffer    uintptr
+	}
+	CommandLine struct {
+		Length    uint16
+		MaxLength uint16
+		Buffer    uintptr
+	}
+	CurrentDirectoryPath struct {
+		Length    uint16
+		MaxLength uint16
+		Buffer    uintptr
+	}
+	DllPath struct {
+		Length    uint16
+		MaxLength uint16
+		Buffer    uintptr
+	}
+	CurrentDirectory string
+}
+
+func CurrentWorkingDirectoryForPid(pid int) (string, error) {
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ,
+		false, uint32(pid))
+	if err == nil {
+		defer windows.CloseHandle(handle)
+		dir, err := readProcessCwd(handle, pid)
+		if err == nil {
+			return dir, nil
+		}
+		// PEB read failed (e.g. access denied), fallback to image path.
+	}
+
+	// Try fallback: get executable path directory as CWD approximation.
+	dir, err2 := queryProcessImagePath(pid)
+	if err2 != nil {
+		return "", errors.Errorf("process %d is not accessible or no longer exists; "+
+			"set JUPYTER_DATA_DIR environment variable or run Jupyter from a directory you have access to",
+			pid)
+	}
+	return dir, nil
+}
+
+func readProcessCwd(handle windows.Handle, pid int) (string, error) {
+	var pbi processBasicInformation
+	var returnLength uint32
+	procNtQueryInformationProcess.Call(
+		uintptr(handle),
+		processBasicInformationClass,
+		uintptr(unsafe.Pointer(&pbi)),
+		uintptr(unsafe.Sizeof(pbi)),
+		uintptr(unsafe.Pointer(&returnLength)),
+	)
+	if pbi.PebBaseAddress == 0 {
+		return "", errors.Errorf("failed to query process basic information for pid %d", pid)
+	}
+
+	var processPeb peb
+	if err := readProcessMemory(handle, pbi.PebBaseAddress, (*byte)(unsafe.Pointer(&processPeb)), unsafe.Sizeof(processPeb)); err != nil {
+		return "", err
+	}
+
+	if processPeb.ProcessParameters == 0 {
+		return "", errors.Errorf("process parameters not found for pid %d", pid)
+	}
+
+	var params rtlUserProcessParameters
+	if err := readProcessMemory(handle, processPeb.ProcessParameters, (*byte)(unsafe.Pointer(&params)), unsafe.Sizeof(params)); err != nil {
+		return "", err
+	}
+
+	if params.CurrentDirectoryPath.Buffer == 0 || params.CurrentDirectoryPath.Length == 0 {
+		return "", errors.Errorf("current directory not available for pid %d", pid)
+	}
+
+	buf := make([]uint16, params.CurrentDirectoryPath.Length/2)
+	if err := readProcessMemory(handle, params.CurrentDirectoryPath.Buffer, (*byte)(unsafe.Pointer(&buf[0])), uintptr(params.CurrentDirectoryPath.Length)); err != nil {
+		return "", err
+	}
+
+	return windows.UTF16ToString(buf), nil
+}
+
+func queryProcessImagePath(pid int) (string, error) {
+	handle, err := windows.OpenProcess(
+		windows.PROCESS_QUERY_LIMITED_INFORMATION,
+		false, uint32(pid))
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to open process %d", pid)
+	}
+	defer windows.CloseHandle(handle)
+
+	buf := make([]uint16, windows.MAX_PATH+1)
+	var size uint32 = uint32(len(buf))
+	err = procQueryFullProcessImageNameW.Find()
+	if err != nil {
+		return "", errors.Wrapf(err, "QueryFullProcessImageNameW not available")
+	}
+	r1, _, _ := procQueryFullProcessImageNameW.Call(
+		uintptr(handle),
+		0,
+		uintptr(unsafe.Pointer(&buf[0])),
+		uintptr(unsafe.Pointer(&size)),
+	)
+	if r1 == 0 {
+		return "", errors.Errorf("QueryFullProcessImageNameW failed for pid %d", pid)
+	}
+
+	exePath := windows.UTF16ToString(buf[:size])
+	return filepath.Dir(exePath), nil
+}
+
+func readProcessMemory(handle windows.Handle, baseAddress uintptr, buffer *byte, size uintptr) error {
+	var nread uintptr
+	err := windows.ReadProcessMemory(handle, baseAddress, buffer, size, &nread)
+	if err != nil {
+		return err
+	}
+	if nread != size {
+		return errors.Errorf("ReadProcessMemory read %d bytes, expected %d", nread, size)
+	}
+	return nil
+}

--- a/internal/goexec/cwd_windows.go
+++ b/internal/goexec/cwd_windows.go
@@ -1,4 +1,4 @@
-//go:build windows
+//go:build windows && !386
 
 package goexec
 
@@ -9,15 +9,12 @@ import (
 	"unsafe"
 )
 
-var (
-	modNtdll   = windows.NewLazySystemDLL("ntdll.dll")
-	modKernel32 = windows.NewLazySystemDLL("kernel32.dll")
-
-	procNtQueryInformationProcess = modNtdll.NewProc("NtQueryInformationProcess")
-	procQueryFullProcessImageNameW = modKernel32.NewProc("QueryFullProcessImageNameW")
-)
-
-const processBasicInformationClass = 0
+type unicodeString struct {
+	Length        uint16
+	MaximumLength uint16
+	_             uint32 // Padding on x64
+	Buffer        uintptr
+}
 
 type processBasicInformation struct {
 	ExitStatus                   uintptr
@@ -28,92 +25,68 @@ type processBasicInformation struct {
 	InheritedFromUniqueProcessID uintptr
 }
 
-type peb struct {
-	Reserved1         [2]byte
-	BeingDebugged     byte
-	Reserved2         byte
-	Reserved3         [2]uintptr
-	Ldr               uintptr
-	ProcessParameters uintptr
-	Reserved4         [3]uintptr
-	Reserved5         uintptr
-	Reserved6         [5]uintptr
-}
-
+// Partial RTL_USER_PROCESS_PARAMETERS layout for 64-bit Windows.
 type rtlUserProcessParameters struct {
-	Reserved1     [16]byte
-	Reserved2     [4]uintptr
-	ImagePathName struct {
-		Length    uint16
-		MaxLength uint16
-		Buffer    uintptr
-	}
-	CommandLine struct {
-		Length    uint16
-		MaxLength uint16
-		Buffer    uintptr
-	}
-	CurrentDirectoryPath struct {
-		Length    uint16
-		MaxLength uint16
-		Buffer    uintptr
-	}
-	DllPath struct {
-		Length    uint16
-		MaxLength uint16
-		Buffer    uintptr
-	}
-	CurrentDirectory string
+	_                    [32]byte
+	_                    [3]windows.Handle
+	CurrentDirectoryPath unicodeString // Offset 0x38 on x64
 }
 
 func CurrentWorkingDirectoryForPid(pid int) (string, error) {
 	handle, err := windows.OpenProcess(
 		windows.PROCESS_QUERY_INFORMATION|windows.PROCESS_VM_READ,
-		false, uint32(pid))
-	if err == nil {
-		defer windows.CloseHandle(handle)
-		dir, err := readProcessCwd(handle, pid)
-		if err == nil {
-			return dir, nil
-		}
-		// PEB read failed (e.g. access denied), fallback to image path.
+		false,
+		uint32(pid),
+	)
+	if err != nil {
+		return queryProcessImagePath(pid)
 	}
+	defer windows.CloseHandle(handle)
 
-	// Try fallback: get executable path directory as CWD approximation.
-	dir, err2 := queryProcessImagePath(pid)
-	if err2 != nil {
-		return "", errors.Errorf("process %d is not accessible or no longer exists; "+
-			"set JUPYTER_DATA_DIR environment variable or run Jupyter from a directory you have access to",
-			pid)
+	dir, err := readProcessCwd(handle, pid)
+	if err != nil {
+		return queryProcessImagePath(pid)
 	}
 	return dir, nil
 }
 
 func readProcessCwd(handle windows.Handle, pid int) (string, error) {
 	var pbi processBasicInformation
-	var returnLength uint32
-	procNtQueryInformationProcess.Call(
-		uintptr(handle),
-		processBasicInformationClass,
-		uintptr(unsafe.Pointer(&pbi)),
-		uintptr(unsafe.Sizeof(pbi)),
-		uintptr(unsafe.Pointer(&returnLength)),
+	var retLen uint32
+	status := windows.NtQueryInformationProcess(
+		handle,
+		0,
+		unsafe.Pointer(&pbi),
+		uint32(unsafe.Sizeof(pbi)),
+		&retLen,
 	)
+	if status != nil {
+		return "", errors.Errorf("NtQueryInformationProcess failed: %v", status)
+	}
 	if pbi.PebBaseAddress == 0 {
-		return "", errors.Errorf("failed to query process basic information for pid %d", pid)
+		return "", errors.Errorf("PEB base address is null for pid %d", pid)
 	}
 
-	var processPeb peb
-	if err := readProcessMemory(handle, pbi.PebBaseAddress, (*byte)(unsafe.Pointer(&processPeb)), unsafe.Sizeof(processPeb)); err != nil {
+	var procParamsPtr uintptr
+	var bytesRead uintptr
+	err := windows.ReadProcessMemory(
+		handle, pbi.PebBaseAddress+0x20,
+		(*byte)(unsafe.Pointer(&procParamsPtr)),
+		uintptr(unsafe.Sizeof(procParamsPtr)),
+		&bytesRead,
+	)
+	if err != nil {
 		return "", err
 	}
 
-	if processPeb.ProcessParameters == 0 {
-		return "", errors.Errorf("process parameters not found for pid %d", pid)
-	}
-
 	var params rtlUserProcessParameters
-	if err := readProcessMemory(handle, processPeb.ProcessParameters, (*byte)(unsafe.Pointer(&params)), unsafe.Sizeof(params)); err != nil {
+	err = windows.ReadProcessMemory(
+		handle, procParamsPtr,
+		(*byte)(unsafe.Pointer(&params)),
+		uintptr(unsafe.Sizeof(params)),
+		&bytesRead,
+	)
+	if err != nil {
 		return "", err
 	}
 
@@ -122,7 +95,14 @@ func readProcessCwd(handle windows.Handle, pid int) (string, error) {
 	}
 
 	buf := make([]uint16, params.CurrentDirectoryPath.Length/2)
-	if err := readProcessMemory(handle, params.CurrentDirectoryPath.Buffer, (*byte)(unsafe.Pointer(&buf[0])), uintptr(params.CurrentDirectoryPath.Length)); err != nil {
+	err = windows.ReadProcessMemory(
+		handle,
+		params.CurrentDirectoryPath.Buffer,
+		(*byte)(unsafe.Pointer(&buf[0])),
+		uintptr(params.CurrentDirectoryPath.Length),
+		&bytesRead,
+	)
+	if err != nil {
 		return "", err
 	}
 
@@ -134,38 +114,18 @@ func queryProcessImagePath(pid int) (string, error) {
 		windows.PROCESS_QUERY_LIMITED_INFORMATION,
 		false, uint32(pid))
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to open process %d", pid)
+		return "", errors.Errorf("process %d is not accessible or no longer exists; "+
+			"set JUPYTER_DATA_DIR environment variable or run Jupyter from a directory you have access to",
+			pid)
 	}
 	defer windows.CloseHandle(handle)
 
 	buf := make([]uint16, windows.MAX_PATH+1)
 	var size uint32 = uint32(len(buf))
-	err = procQueryFullProcessImageNameW.Find()
+	err = windows.QueryFullProcessImageName(handle, 0, &buf[0], &size)
 	if err != nil {
-		return "", errors.Wrapf(err, "QueryFullProcessImageNameW not available")
-	}
-	r1, _, _ := procQueryFullProcessImageNameW.Call(
-		uintptr(handle),
-		0,
-		uintptr(unsafe.Pointer(&buf[0])),
-		uintptr(unsafe.Pointer(&size)),
-	)
-	if r1 == 0 {
-		return "", errors.Errorf("QueryFullProcessImageNameW failed for pid %d", pid)
+		return "", err
 	}
 
-	exePath := windows.UTF16ToString(buf[:size])
-	return filepath.Dir(exePath), nil
-}
-
-func readProcessMemory(handle windows.Handle, baseAddress uintptr, buffer *byte, size uintptr) error {
-	var nread uintptr
-	err := windows.ReadProcessMemory(handle, baseAddress, buffer, size, &nread)
-	if err != nil {
-		return err
-	}
-	if nread != size {
-		return errors.Errorf("ReadProcessMemory read %d bytes, expected %d", nread, size)
-	}
-	return nil
+	return filepath.Dir(windows.UTF16ToString(buf[:size])), nil
 }

--- a/internal/goexec/execcode.go
+++ b/internal/goexec/execcode.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 )
@@ -151,7 +152,11 @@ func (s *State) PostExecuteCell() {
 
 // BinaryPath is the path to the generated binary file.
 func (s *State) BinaryPath() string {
-	return path.Join(s.TempDir, s.Package)
+	binaryPath := path.Join(s.TempDir, s.Package)
+	if runtime.GOOS == "windows" {
+		binaryPath += ".exe"
+	}
+	return binaryPath
 }
 
 const (

--- a/internal/goexec/goplsclient/conn.go
+++ b/internal/goexec/goplsclient/conn.go
@@ -76,6 +76,9 @@ func (c *Client) Connect(ctx context.Context) error {
 	} else if strings.HasPrefix(addr, "unix;") {
 		netMethod = "unix"
 		addr = addr[5:]
+	} else if strings.HasPrefix(addr, "tcp;") {
+		netMethod = "tcp"
+		addr = addr[4:]
 	}
 	var err error
 	c.conn, err = net.DialTimeout(netMethod, addr, ConnectTimeout)

--- a/internal/goexec/goplsclient/exec.go
+++ b/internal/goexec/goplsclient/exec.go
@@ -21,25 +21,30 @@ import (
 
 var StartTimeout = 30 * time.Second
 
+// GetFreePort asks the OS for an available port on localhost.
+// It works on dual-stack IPv4/IPv6 on the loopback interface.
+func GetFreePort() (int, error) {
+	l, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		return 0, err
+	}
+	defer l.Close()
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
 // resolveWindowsGoplsAddr resolves the gopls address for Windows.
 // If addr is "127.0.0.1:0", it finds a free port and updates c.address
 // so the client knows which port to connect to.
 func resolveWindowsGoplsAddr(c *Client, addr string) string {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil || port != "0" {
-		// Not a :0 address, use as-is with tcp; prefix.
 		return "tcp;" + addr
 	}
-	// Find a free port by listening on :0 and closing.
-	listener, err := net.Listen("tcp", host+":0")
+	freePort, err := GetFreePort()
 	if err != nil {
 		klog.Warningf("gopls: failed to find free port, using :0: %v", err)
 		return "tcp;" + addr
 	}
-	freePort := listener.Addr().(*net.TCPAddr).Port
-	_ = listener.Close()
-
-	// Update client address to the actual port so Connect() can find gopls.
 	c.address = fmt.Sprintf("%s:%d", host, freePort)
 	return fmt.Sprintf("tcp;%s:%d", host, freePort)
 }

--- a/internal/goexec/goplsclient/exec.go
+++ b/internal/goexec/goplsclient/exec.go
@@ -2,10 +2,12 @@ package goplsclient
 
 import (
 	"context"
+	"fmt"
+	"net"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/janpfeifer/gonb/internal/util"
@@ -18,6 +20,29 @@ import (
 // as a server for the duration of the kernel.
 
 var StartTimeout = 30 * time.Second
+
+// resolveWindowsGoplsAddr resolves the gopls address for Windows.
+// If addr is "127.0.0.1:0", it finds a free port and updates c.address
+// so the client knows which port to connect to.
+func resolveWindowsGoplsAddr(c *Client, addr string) string {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil || port != "0" {
+		// Not a :0 address, use as-is with tcp; prefix.
+		return "tcp;" + addr
+	}
+	// Find a free port by listening on :0 and closing.
+	listener, err := net.Listen("tcp", host+":0")
+	if err != nil {
+		klog.Warningf("gopls: failed to find free port, using :0: %v", err)
+		return "tcp;" + addr
+	}
+	freePort := listener.Addr().(*net.TCPAddr).Port
+	_ = listener.Close()
+
+	// Update client address to the actual port so Connect() can find gopls.
+	c.address = fmt.Sprintf("%s:%d", host, freePort)
+	return fmt.Sprintf("tcp;%s:%d", host, freePort)
+}
 
 // Start `gopls` as a server, on `Client.Address()` port. It is started
 // asynchronously (so `Start()` returns immediately) and is followed up
@@ -44,14 +69,12 @@ func (c *Client) Start() error {
 	addr := c.Address()
 	if strings.HasPrefix(addr, "/") {
 		addr = "unix;" + addr
+	} else if runtime.GOOS == "windows" {
+		addr = resolveWindowsGoplsAddr(c, addr)
 	}
 	c.goplsExec = exec.Command(goplsPath, "-listen", addr)
 
-	// Start on its own process group, to avoid receiving the `sigint` that
-	// the kernel receives from Jupyter and dying.
-	// Not sure on the status of MacOS:
-	// https://stackoverflow.com/questions/43364958/start-command-with-new-process-group-id-golang
-	c.goplsExec.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+	setNewProcessGroup(c.goplsExec)
 	c.goplsExec.Dir = c.dir
 	klog.Infof("Executing %q", c.goplsExec)
 	err = c.goplsExec.Start()

--- a/internal/goexec/goplsclient/exec_unix.go
+++ b/internal/goexec/goplsclient/exec_unix.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package goplsclient
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func setNewProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true, Pgid: 0}
+}

--- a/internal/goexec/goplsclient/exec_windows.go
+++ b/internal/goexec/goplsclient/exec_windows.go
@@ -6,5 +6,6 @@ import (
 	"os/exec"
 )
 
+// setNewProcessGroup is a no-op for Windows, it doesn't support process groups.
 func setNewProcessGroup(cmd *exec.Cmd) {
 }

--- a/internal/goexec/goplsclient/exec_windows.go
+++ b/internal/goexec/goplsclient/exec_windows.go
@@ -1,0 +1,10 @@
+//go:build windows
+
+package goplsclient
+
+import (
+	"os/exec"
+)
+
+func setNewProcessGroup(cmd *exec.Cmd) {
+}

--- a/internal/goexec/goplsclient/exec_windows.go
+++ b/internal/goexec/goplsclient/exec_windows.go
@@ -4,8 +4,11 @@ package goplsclient
 
 import (
 	"os/exec"
+	"syscall"
 )
 
-// setNewProcessGroup is a no-op for Windows, it doesn't support process groups.
 func setNewProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
 }

--- a/internal/goexec/goplsclient/goplsclient.go
+++ b/internal/goexec/goplsclient/goplsclient.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"runtime"
 	"sync"
 	"time"
 
@@ -70,7 +71,7 @@ type Client struct {
 func New(dir string) *Client {
 	c := &Client{
 		dir:          dir,
-		address:      path.Join(dir, "gopls_socket"),
+		address:      defaultAddress(dir),
 		fileVersions: make(map[string]int),
 		fileCache:    make(map[string]*FileData),
 
@@ -78,6 +79,18 @@ func New(dir string) *Client {
 	}
 	return c
 }
+
+// defaultAddress returns the default gopls listen address for the platform.
+// On Unix: a Unix socket path under dir.
+// On Windows: a TCP address on localhost with a random available port.
+func defaultAddress(dir string) string {
+	if runtime.GOOS == "windows" {
+		return "127.0.0.1:0"
+	}
+	return path.Join(dir, "gopls_socket")
+}
+
+
 
 // Address used either to start `gopls` or to connect to it.
 func (c *Client) Address() string { return c.address }

--- a/internal/jpyexec/jpyexec.go
+++ b/internal/jpyexec/jpyexec.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	osexec "os/exec"
 	"sync"
-	"syscall"
 	"time"
 )
 
@@ -61,6 +60,11 @@ type Executor struct {
 	//
 	// Notice the contents are written raw, without the mime-type.
 	captureDisplayDataOutput io.Writer
+
+	// namedPipeReaderHandle and namedPipeWriterHandle are used on Windows to store
+	// the named pipe server handles before they are converted to *os.File.
+	namedPipeReaderHandle uintptr
+	namedPipeWriterHandle uintptr
 
 	isDone    bool
 	doneChan  chan struct{}
@@ -264,8 +268,7 @@ func (exec *Executor) Exec() error {
 		case <-exec.doneChan:
 			// Normal stop, nothing to do.
 		case <-time.After(WaitToKill):
-			// If process hasn't yet died, kill it.
-			err = cmd.Process.Signal(syscall.SIGKILL)
+			err = cmd.Process.Kill()
 			if err != nil {
 				klog.Errorf("failed to kill process %s (%v): %+v", cmd, cmd.Process, err)
 			}

--- a/internal/jpyexec/namedpipes.go
+++ b/internal/jpyexec/namedpipes.go
@@ -1,71 +1,19 @@
+//go:build !windows
+
 package jpyexec
 
-// This file implements the polling on the $GONB_PIPE and $GONB_PIPE_WIDGETS named pipes created
-// to receive information from the program being executed and to send information from the
-// widgets.
-//
-// It has a protocol (defined under `gonbui/protocol`) to display rich content.
-
 import (
-	"encoding/gob"
-	"fmt"
 	"github.com/janpfeifer/gonb/gonbui/protocol"
-	"github.com/janpfeifer/gonb/internal/kernel"
 	"github.com/pkg/errors"
-	"io"
 	"k8s.io/klog/v2"
 	"os"
 	"sync"
 	"syscall"
 )
 
-func init() {
-	// Register generic gob types we want to make sure are understood.
-	gob.Register(map[string]any{})
-	gob.Register([]string{})
-	gob.Register([]any{})
-}
-
-// CommsHandler interface is used if Executor.UseNamedPipes is called, and a CommsHandler
-// is provided.
-//
-// It is assumed there is at most one program being executed at a time. GoNB will never
-// execute two cells simultaneously.
-type CommsHandler interface {
-	// ProgramStart is called when the program execution is about to start.
-	// If program start failed (e.g.: during creation of pipes), ProgramStart may not be called,
-	// and yet ProgramFinished is called.
-	ProgramStart(exec *Executor)
-
-	// ProgramFinished is called when the program execution finishes.
-	// Notice this may be called even if ProgramStart has not been called, if the execution
-	// failed during the creation of the various pipes.
-	ProgramFinished()
-
-	// ProgramSendValueRequest is called when the program requests a value to be sent to an address.
-	ProgramSendValueRequest(address string, value any)
-
-	// ProgramReadValueRequest handler.
-	ProgramReadValueRequest(address string)
-
-	// ProgramSubscribeRequest handler.
-	ProgramSubscribeRequest(address string)
-
-	// ProgramUnsubscribeRequest handler.
-	ProgramUnsubscribeRequest(address string)
-}
-
-// PipeWriterFifoBufferSize is the number of CommValue messages that
-// can be buffered when writing to the named pipe before dropping.
-const PipeWriterFifoBufferSize = 128
-
-// handleNamedPipes creates the named pipe and set up the goroutines to listen to them.
-//
-// TODO: make this more secure, maybe with a secret key also passed by the environment.
 func (exec *Executor) handleNamedPipes() (err error) {
 	exec.PipeWriterFifo = make(chan *protocol.CommValue, PipeWriterFifoBufferSize)
 
-	// Create temporary named pipes in both directions.
 	exec.namedPipeReaderPath, err = exec.createTmpFifo()
 	if err != nil {
 		return errors.Wrapf(err, "creating named pipe used to read from program %s", exec.cmd)
@@ -84,7 +32,6 @@ func (exec *Executor) handleNamedPipes() (err error) {
 }
 
 func (exec *Executor) createTmpFifo() (string, error) {
-	// Create a temporary file name.
 	f, err := os.CreateTemp(exec.dir, "gonb_pipe_")
 	if err != nil {
 		return "", err
@@ -97,38 +44,22 @@ func (exec *Executor) createTmpFifo() (string, error) {
 		return "", err
 	}
 
-	// Create pipe.
 	if err = syscall.Mkfifo(pipePath, 0600); err != nil {
 		return "", errors.Wrapf(err, "failed to create pipe (Mkfifo) for %q", pipePath)
 	}
 	return pipePath, nil
 }
 
-// openPipeReader opens `exec.namedPipeReaderPath` and handles its proper closing, and removal of
-// the named pipe when program execution is finished.
-//
-// The doneChan is listened to: when it is closed, it will trigger the listener goroutine to close the pipe,
-// remove it and quit.
 func (exec *Executor) openPipeReader() {
-	// Synchronize pipe: if it's not opened by the program being executed,
-	// we have to open it ourselves for writing, to avoid blocking
-	// `os.Open` (it waits the other end of the fifo to be opened before returning).
-	// See discussion in:
-	// https://stackoverflow.com/questions/75255426/how-to-interrupt-a-blocking-os-open-call-waiting-on-a-fifo-in-go
 	var muFifo sync.Mutex
 	fifoOpenedForReading := false
 
 	go func() {
-		// Clean up after program is over, there are two scenarios:
-		// 1. The executed program opened the pipe: then we just remove the pipePath.
-		// 2. The executed program never opened the pipe: then the other end (goroutine
-		//    below) will be forever blocked on os.Open call.
 		<-exec.doneChan
 		muFifo.Lock()
 		if !fifoOpenedForReading {
 			w, err := os.OpenFile(exec.namedPipeReaderPath, os.O_WRONLY, 0600)
 			if err == nil {
-				// Closing it allows the open of the pipe for reading (below) to unblock.
 				_ = w.Close()
 			}
 		}
@@ -139,11 +70,8 @@ func (exec *Executor) openPipeReader() {
 	go func() {
 		klog.V(2).Infof("Opening named pipeReader in %q", exec.namedPipeReaderPath)
 		if exec.isDone {
-			// In case program execution interrupted early.
 			return
 		}
-		// Notice that opening pipeReader below blocks, until the other end
-		// (the go program being executed) opens it as well.
 		var err error
 		exec.pipeReader, err = os.Open(exec.namedPipeReaderPath)
 		if err != nil {
@@ -155,221 +83,24 @@ func (exec *Executor) openPipeReader() {
 		fifoOpenedForReading = true
 		defer muFifo.Unlock()
 
-		// Start polling of the pipeReader.
 		go exec.pollNamedPipeReader()
 
-		// Wait program execution to finish to close reader (in case it is not yet closed).
 		<-exec.doneChan
 		_ = exec.pipeReader.Close()
 		_ = os.Remove(exec.namedPipeReaderPath)
 	}()
 }
 
-// pollNamedPipeReader will continuously read for incoming requests with displaying content
-// on the notebook or widgets updates.
-func (exec *Executor) pollNamedPipeReader() {
-	decoder := gob.NewDecoder(exec.pipeReader)
-	for {
-		data := &protocol.DisplayData{}
-		err := decoder.Decode(data)
-		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, os.ErrClosed) {
-			return
-		} else if err != nil {
-			klog.Infof("Named pipe: failed to parse message: %+v", err)
-			return
-		}
-
-		// Special case for a request for input:
-		if reqAny, found := data.Data[protocol.MIMEJupyterInput]; found {
-			klog.V(2).Infof("Received InputRequest: %v", reqAny)
-			req, ok := reqAny.(protocol.InputRequest)
-			if !ok {
-				exec.reportCellError(errors.Errorf(
-					"A MIMEJupyterInput sent to GONB_PIPE without an associated protocol.InputRequest!? -- got (%T) %#v",
-					reqAny, reqAny))
-				continue
-			}
-			exec.dispatchInputRequest(&req)
-			continue
-		}
-
-		// CommValue: update or read value in the front-end.
-		if reqAny, found := data.Data[protocol.MIMECommValue]; found {
-			req, ok := reqAny.(protocol.CommValue)
-			if !ok {
-				exec.reportCellError(errors.Errorf(
-					"Invalid message sent in named pipes to GoNB from cell, "+
-						"this may affect widgets communication -- "+
-						"MIMECommValue sent to $GONB_PIPE_BACK without an associated `protocol.CommValue` "+
-						"type, got %T instead", reqAny))
-				continue
-			}
-
-			// Special addresses:
-			if req.Address == protocol.GonbuiSyncAddress {
-				syncId, ok := req.Value.(int)
-				if !ok {
-					klog.Errorf("comms: Receive Sync request with invalid value %+v. Communication with cell program may be left in an unusable state!", req)
-					continue
-				}
-				klog.V(2).Infof("comms: Received Sync(%d) at %q, sending back ack", syncId, req.Address)
-				// Acknowledge with a reply to the special address.
-				exec.PipeWriterFifo <- &protocol.CommValue{
-					Address: protocol.GonbuiSyncAckAddress,
-					Value:   syncId,
-				}
-				continue
-			}
-
-			if exec.commsHandler == nil {
-				klog.V(2).Infof("Received and dropped (no handler registered) CommValue: %+v", req)
-			} else if req.Request {
-				klog.V(2).Infof("ProgramReadValueRequest(%q) requested", req.Address)
-				exec.commsHandler.ProgramReadValueRequest(req.Address)
-			} else {
-				klog.V(2).Infof("ProgramSendValueRequest(%q, %v) requested", req.Address, req.Value)
-				exec.commsHandler.ProgramSendValueRequest(req.Address, req.Value)
-			}
-			continue
-		}
-
-		// ProgramSubscribeRequest: (un-)subscribe to address in the front-end.
-		if reqAny, found := data.Data[protocol.MIMECommSubscribe]; found {
-			req, ok := reqAny.(protocol.CommSubscription)
-			if !ok {
-				exec.reportCellError(errors.Errorf(
-					"Invalid message sent in named pipes to GoNB from cell, "+
-						"this may affect widgets communication -- "+
-						"MIMECommSubscribe sent to $GONB_PIPE_BACK without an associated `protocol.CommSubscription` "+
-						"type, got %T instead", reqAny))
-				continue
-			}
-			if exec.commsHandler == nil {
-				klog.V(2).Infof("Received and dropped (no handler registered) ProgramSubscribeRequest: %+v", req)
-			} else if req.Unsubscribe {
-				klog.V(2).Infof("ProgramUnsubscribeRequest(%q) requested", req.Address)
-				exec.commsHandler.ProgramUnsubscribeRequest(req.Address)
-			} else {
-				klog.V(2).Infof("ProgramSubscribeRequest(%q) requested", req.Address)
-				exec.commsHandler.ProgramSubscribeRequest(req.Address)
-			}
-			continue
-		}
-
-		// Otherwise, just display with the corresponding MIME type:
-		exec.dispatchDisplayData(data)
-	}
-}
-
-// reportCellError reports error to both, the notebook and the standard logger (gonb's stderr).
-func (exec *Executor) reportCellError(err error) {
-	errStr := fmt.Sprintf("%+v", err) // Error with stack.
-	klog.Errorf("%s", errStr)
-	err = kernel.PublishWriteStream(exec.Msg, kernel.StreamStderr, "GoNB Error:\n"+errStr)
-	if err != nil {
-		klog.Errorf("%+v", errors.WithStack(err))
-	}
-}
-
-// dispatchDisplayData received through the named pipe (`$GONB_PIPE`).
-func (exec *Executor) dispatchDisplayData(data *protocol.DisplayData) {
-	// Log info about what is being displayed.
-	msgData := kernel.Data{
-		Data:      make(kernel.MIMEMap, len(data.Data)),
-		Metadata:  make(kernel.MIMEMap),
-		Transient: make(kernel.MIMEMap),
-	}
-	for mimeType, content := range data.Data {
-		msgData.Data[string(mimeType)] = content
-
-		// Capture display data output, if requested.
-		if exec.captureDisplayDataOutput != nil {
-			str, ok := content.(string)
-			if ok {
-				_, err := exec.captureDisplayDataOutput.Write([]byte(str))
-				if err != nil {
-					klog.Errorf("failed to capture display data output: %v", err)
-				}
-			}
-		}
-	}
-
-	if klog.V(1).Enabled() {
-		kernel.LogDisplayData(msgData.Data)
-	}
-	for key, content := range data.Metadata {
-		msgData.Metadata[key] = content
-	}
-	var err error
-	if data.DisplayID != "" {
-		msgData.Transient["display_id"] = data.DisplayID
-		err = kernel.PublishUpdateDisplayData(exec.Msg, msgData)
-	} else {
-		err = kernel.PublishData(exec.Msg, msgData)
-	}
-	if err != nil {
-		klog.Errorf("Failed to display data (ignoring): %v", err)
-	}
-}
-
-// dispatchInputRequest uses the standard Jupyter input mechanism.
-// It is fundamentally broken -- it locks the UI even if the program already stopped running --
-// so we suggest using the `gonb/gonbui/widgets` API instead.
-func (exec *Executor) dispatchInputRequest(req *protocol.InputRequest) {
-	klog.V(2).Infof("Received InputRequest %+v", req)
-	writeStdinFn := func(original, input *kernel.MessageImpl) error {
-		content := input.Composed.Content.(map[string]any)
-		value := content["value"].(string) + "\n"
-		klog.V(2).Infof("stdin value: %q", value)
-		go func() {
-			exec.muDone.Lock()
-			cmdStdin := exec.cmdStdin
-			exec.muDone.Unlock()
-			if exec.isDone {
-				return
-			}
-			// Write concurrently, not to block, in case program doesn't
-			// actually read anything from the stdin.
-			_, err := cmdStdin.Write([]byte(value))
-			if err != nil {
-				// Could happen if something was not fully written, and channel was closed, in
-				// which case it's ok.
-				klog.Warningf("failed to write to stdin of cell: %+v", err)
-			}
-		}()
-		return nil
-	}
-	err := exec.Msg.PromptInput(req.Prompt, req.Password, writeStdinFn)
-	if err != nil {
-		exec.reportCellError(err)
-	}
-}
-
-// openPipeWriter opens `exec.namedPipeWriterPath` and handles its proper closing, and removal of
-// the named pipe when program execution is finished.
-//
-// The doneChan is listened to: when it is closed, it will trigger the listener goroutine to close the pipe,
-// remove it and quit.
 func (exec *Executor) openPipeWriter() {
-	// Synchronize pipe: if it's not opened by the program being executed,
-	// we have to open it ourselves for writing, to avoid blocking
-	// `os.Open` (it waits the other end of the fifo to be opened before returning).
-	// See discussion in:
-	// https://stackoverflow.com/questions/75255426/how-to-interrupt-a-blocking-os-open-call-waiting-on-a-fifo-in-go
 	var muFifo sync.Mutex
 	fifoOpened := false
 
 	go func() {
-		// Clean up after program is over, there are two scenarios:
-		// 1. The executed program opened the pipe: then we just remove the pipePath.
-		// 2. The executed program never opened the pipe: then the other end (goroutine
-		//    below) will be forever blocked on os.Open call.
 		<-exec.doneChan
 		muFifo.Lock()
 		if !fifoOpened {
 			r, err := os.OpenFile(exec.namedPipeWriterPath, os.O_RDONLY, 0600)
 			if err == nil {
-				// Closing it allows the open of the pipe for writing (below) to unblock.
 				_ = r.Close()
 			}
 		}
@@ -380,12 +111,9 @@ func (exec *Executor) openPipeWriter() {
 	go func() {
 		klog.V(2).Infof("Opening named pipeWriter in %q", exec.namedPipeWriterPath)
 		if exec.isDone {
-			// In case program execution interrupted early.
 			klog.Warningf("Opening of NamedPipeWriter in %q failed, since program already stopped/crashed", exec.namedPipeWriterPath)
 			return
 		}
-		// Notice that opening the pipe below blocks, until the other end (the go program being executed) opens it
-		// as well.
 		f, err := os.OpenFile(exec.namedPipeWriterPath, os.O_WRONLY, 0600)
 		if err != nil {
 			klog.Warningf("Failed to open pipe (Mkfifo) %q for writing: %+v", exec.namedPipeWriterPath, err)
@@ -397,35 +125,11 @@ func (exec *Executor) openPipeWriter() {
 		fifoOpened = true
 		defer muFifo.Unlock()
 
-		// Start polling of the pipeReader.
 		go exec.pollPipeWriterFifo()
 
-		// Wait program execution to finish to close the writer (file and fifo).
 		<-exec.doneChan
 		close(exec.PipeWriterFifo)
 		_ = exec.pipeWriter.Close()
 		_ = os.Remove(exec.namedPipeWriterPath)
 	}()
-}
-
-// pollPipeWriterFifo polls messages from `Executor.PipeWriterFifo` and encodes them to
-// the named pipe writer.
-func (exec *Executor) pollPipeWriterFifo() {
-	encoder := gob.NewEncoder(exec.pipeWriter)
-	klog.V(2).Infof("jpyexec: pollPipeWriterFifo() listening to requests.")
-	for msg := range exec.PipeWriterFifo {
-		if klog.V(2).Enabled() {
-			klog.Infof("jpyexec: encoding %+v to named pipe to cell program", msg)
-		}
-		err := encoder.Encode(msg)
-		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, os.ErrClosed) {
-			return
-		} else if err != nil {
-			klog.Infof("while writing to cell program, failed to encode message %+v. "+
-				"Communication with cell program broken, widgets won't work properly. "+
-				"You can try re-executing the cell. Error: %+v", msg, err)
-			return
-		}
-	}
-	klog.V(2).Infof("jpyexec: pollPipeWriterFifo() closed.")
 }

--- a/internal/jpyexec/namedpipes_dispatch.go
+++ b/internal/jpyexec/namedpipes_dispatch.go
@@ -1,0 +1,210 @@
+package jpyexec
+
+import (
+	"encoding/gob"
+	"fmt"
+	"github.com/janpfeifer/gonb/gonbui/protocol"
+	"github.com/janpfeifer/gonb/internal/kernel"
+	"github.com/pkg/errors"
+	"io"
+	"k8s.io/klog/v2"
+	"os"
+)
+
+func init() {
+	gob.Register(map[string]any{})
+	gob.Register([]string{})
+	gob.Register([]any{})
+}
+
+type CommsHandler interface {
+	ProgramStart(exec *Executor)
+	ProgramFinished()
+	ProgramSendValueRequest(address string, value any)
+	ProgramReadValueRequest(address string)
+	ProgramSubscribeRequest(address string)
+	ProgramUnsubscribeRequest(address string)
+}
+
+const PipeWriterFifoBufferSize = 128
+
+func (exec *Executor) pollNamedPipeReader() {
+	decoder := gob.NewDecoder(exec.pipeReader)
+	for {
+		data := &protocol.DisplayData{}
+		err := decoder.Decode(data)
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, os.ErrClosed) {
+			return
+		} else if err != nil {
+			klog.Infof("Named pipe: failed to parse message: %+v", err)
+			return
+		}
+
+		if reqAny, found := data.Data[protocol.MIMEJupyterInput]; found {
+			klog.V(2).Infof("Received InputRequest: %v", reqAny)
+			req, ok := reqAny.(protocol.InputRequest)
+			if !ok {
+				exec.reportCellError(errors.Errorf(
+					"A MIMEJupyterInput sent to GONB_PIPE without an associated protocol.InputRequest!? -- got (%T) %#v",
+					reqAny, reqAny))
+				continue
+			}
+			exec.dispatchInputRequest(&req)
+			continue
+		}
+
+		if reqAny, found := data.Data[protocol.MIMECommValue]; found {
+			req, ok := reqAny.(protocol.CommValue)
+			if !ok {
+				exec.reportCellError(errors.Errorf(
+					"Invalid message sent in named pipes to GoNB from cell, "+
+						"this may affect widgets communication -- "+
+						"MIMECommValue sent to $GONB_PIPE_BACK without an associated `protocol.CommValue` "+
+						"type, got %T instead", reqAny))
+				continue
+			}
+
+			if req.Address == protocol.GonbuiSyncAddress {
+				syncId, ok := req.Value.(int)
+				if !ok {
+					klog.Errorf("comms: Receive Sync request with invalid value %+v. Communication with cell program may be left in an unusable state!", req)
+					continue
+				}
+				klog.V(2).Infof("comms: Received Sync(%d) at %q, sending back ack", syncId, req.Address)
+				exec.PipeWriterFifo <- &protocol.CommValue{
+					Address: protocol.GonbuiSyncAckAddress,
+					Value:   syncId,
+				}
+				continue
+			}
+
+			if exec.commsHandler == nil {
+				klog.V(2).Infof("Received and dropped (no handler registered) CommValue: %+v", req)
+			} else if req.Request {
+				klog.V(2).Infof("ProgramReadValueRequest(%q) requested", req.Address)
+				exec.commsHandler.ProgramReadValueRequest(req.Address)
+			} else {
+				klog.V(2).Infof("ProgramSendValueRequest(%q, %v) requested", req.Address, req.Value)
+				exec.commsHandler.ProgramSendValueRequest(req.Address, req.Value)
+			}
+			continue
+		}
+
+		if reqAny, found := data.Data[protocol.MIMECommSubscribe]; found {
+			req, ok := reqAny.(protocol.CommSubscription)
+			if !ok {
+				exec.reportCellError(errors.Errorf(
+					"Invalid message sent in named pipes to GoNB from cell, "+
+						"this may affect widgets communication -- "+
+						"MIMECommSubscribe sent to $GONB_PIPE_BACK without an associated `protocol.CommSubscription` "+
+						"type, got %T instead", reqAny))
+				continue
+			}
+			if exec.commsHandler == nil {
+				klog.V(2).Infof("Received and dropped (no handler registered) ProgramSubscribeRequest: %+v", req)
+			} else if req.Unsubscribe {
+				klog.V(2).Infof("ProgramUnsubscribeRequest(%q) requested", req.Address)
+				exec.commsHandler.ProgramUnsubscribeRequest(req.Address)
+			} else {
+				klog.V(2).Infof("ProgramSubscribeRequest(%q) requested", req.Address)
+				exec.commsHandler.ProgramSubscribeRequest(req.Address)
+			}
+			continue
+		}
+
+		exec.dispatchDisplayData(data)
+	}
+}
+
+func (exec *Executor) pollPipeWriterFifo() {
+	encoder := gob.NewEncoder(exec.pipeWriter)
+	klog.V(2).Infof("jpyexec: pollPipeWriterFifo() listening to requests.")
+	for msg := range exec.PipeWriterFifo {
+		if klog.V(2).Enabled() {
+			klog.Infof("jpyexec: encoding %+v to named pipe to cell program", msg)
+		}
+		err := encoder.Encode(msg)
+		if errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) || errors.Is(err, os.ErrClosed) {
+			return
+		} else if err != nil {
+			klog.Infof("while writing to cell program, failed to encode message %+v. "+
+				"Communication with cell program broken, widgets won't work properly. "+
+				"You can try re-executing the cell. Error: %+v", msg, err)
+			return
+		}
+	}
+	klog.V(2).Infof("jpyexec: pollPipeWriterFifo() closed.")
+}
+
+func (exec *Executor) reportCellError(err error) {
+	errStr := fmt.Sprintf("%+v", err)
+	klog.Errorf("%s", errStr)
+	err = kernel.PublishWriteStream(exec.Msg, kernel.StreamStderr, "GoNB Error:\n"+errStr)
+	if err != nil {
+		klog.Errorf("%+v", errors.WithStack(err))
+	}
+}
+
+func (exec *Executor) dispatchDisplayData(data *protocol.DisplayData) {
+	msgData := kernel.Data{
+		Data:      make(kernel.MIMEMap, len(data.Data)),
+		Metadata:  make(kernel.MIMEMap),
+		Transient: make(kernel.MIMEMap),
+	}
+	for mimeType, content := range data.Data {
+		msgData.Data[string(mimeType)] = content
+
+		if exec.captureDisplayDataOutput != nil {
+			str, ok := content.(string)
+			if ok {
+				_, err := exec.captureDisplayDataOutput.Write([]byte(str))
+				if err != nil {
+					klog.Errorf("failed to capture display data output: %v", err)
+				}
+			}
+		}
+	}
+
+	if klog.V(1).Enabled() {
+		kernel.LogDisplayData(msgData.Data)
+	}
+	for key, content := range data.Metadata {
+		msgData.Metadata[key] = content
+	}
+	var err error
+	if data.DisplayID != "" {
+		msgData.Transient["display_id"] = data.DisplayID
+		err = kernel.PublishUpdateDisplayData(exec.Msg, msgData)
+	} else {
+		err = kernel.PublishData(exec.Msg, msgData)
+	}
+	if err != nil {
+		klog.Errorf("Failed to display data (ignoring): %v", err)
+	}
+}
+
+func (exec *Executor) dispatchInputRequest(req *protocol.InputRequest) {
+	klog.V(2).Infof("Received InputRequest %+v", req)
+	writeStdinFn := func(original, input *kernel.MessageImpl) error {
+		content := input.Composed.Content.(map[string]any)
+		value := content["value"].(string) + "\n"
+		klog.V(2).Infof("stdin value: %q", value)
+		go func() {
+			exec.muDone.Lock()
+			cmdStdin := exec.cmdStdin
+			exec.muDone.Unlock()
+			if exec.isDone {
+				return
+			}
+			_, err := cmdStdin.Write([]byte(value))
+			if err != nil {
+				klog.Warningf("failed to write to stdin of cell: %+v", err)
+			}
+		}()
+		return nil
+	}
+	err := exec.Msg.PromptInput(req.Prompt, req.Password, writeStdinFn)
+	if err != nil {
+		exec.reportCellError(err)
+	}
+}

--- a/internal/jpyexec/namedpipes_windows.go
+++ b/internal/jpyexec/namedpipes_windows.go
@@ -1,0 +1,142 @@
+//go:build windows
+
+package jpyexec
+
+import (
+	"github.com/janpfeifer/gonb/common"
+	"github.com/janpfeifer/gonb/gonbui/protocol"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
+	"k8s.io/klog/v2"
+	"os"
+	"sync"
+)
+
+func (exec *Executor) handleNamedPipes() (err error) {
+	exec.PipeWriterFifo = make(chan *protocol.CommValue, PipeWriterFifoBufferSize)
+
+	exec.namedPipeReaderPath, exec.namedPipeReaderHandle, err = createWindowsPipe(exec.dir)
+	if err != nil {
+		return errors.Wrapf(err, "creating Windows named pipe to read from program %s", exec.cmd)
+	}
+	exec.namedPipeWriterPath, exec.namedPipeWriterHandle, err = createWindowsPipe(exec.dir)
+	if err != nil {
+		cleanupHandle(exec.namedPipeReaderHandle)
+		return errors.Wrapf(err, "creating Windows named pipe to write to program %s", exec.cmd)
+	}
+
+	exec.cmd.Env = append(exec.cmd.Environ(),
+		protocol.GONB_PIPE_ENV+"="+exec.namedPipeReaderPath,
+		protocol.GONB_PIPE_BACK_ENV+"="+exec.namedPipeWriterPath)
+
+	exec.openPipeReader()
+	exec.openPipeWriter()
+	return
+}
+
+func createWindowsPipe(dir string) (pipePath string, rawHandle uintptr, err error) {
+	pipePath = `\\.\pipe\gonb_` + common.UniqueId()
+	pathp, err := windows.UTF16PtrFromString(pipePath)
+	if err != nil {
+		return "", 0, err
+	}
+
+	handle, err := windows.CreateNamedPipe(
+		pathp,
+		windows.PIPE_ACCESS_DUPLEX,
+		windows.PIPE_TYPE_BYTE|windows.PIPE_READMODE_BYTE|windows.PIPE_WAIT,
+		windows.PIPE_UNLIMITED_INSTANCES,
+		65536, 65536,
+		0, nil)
+	if err != nil {
+		return "", 0, errors.Wrapf(err, "failed to create Windows named pipe %q", pipePath)
+	}
+	return pipePath, uintptr(handle), nil
+}
+
+func cleanupHandle(rawHandle uintptr) {
+	if rawHandle != 0 {
+		_ = windows.CloseHandle(windows.Handle(rawHandle))
+	}
+}
+
+func (exec *Executor) openPipeReader() {
+	var muFifo sync.Mutex
+	fifoOpenedForReading := false
+
+	go func() {
+		<-exec.doneChan
+		muFifo.Lock()
+		if !fifoOpenedForReading {
+			cleanupHandle(exec.namedPipeReaderHandle)
+		}
+		muFifo.Unlock()
+	}()
+
+	go func() {
+		klog.V(2).Infof("Connecting Windows named pipeReader in %q", exec.namedPipeReaderPath)
+		if exec.isDone {
+			return
+		}
+		handle := windows.Handle(exec.namedPipeReaderHandle)
+		err := windows.ConnectNamedPipe(handle, nil)
+		if err != nil && err != windows.ERROR_PIPE_CONNECTED {
+			klog.Warningf("Failed to connect Windows named pipe %q for reading: %+v", exec.namedPipeReaderPath, err)
+			return
+		}
+		klog.V(2).Infof("Connected Windows named pipeReader in %q", exec.namedPipeReaderPath)
+		exec.pipeReader = os.NewFile(exec.namedPipeReaderHandle, exec.namedPipeReaderPath)
+		muFifo.Lock()
+		fifoOpenedForReading = true
+		defer muFifo.Unlock()
+
+		go exec.pollNamedPipeReader()
+
+		<-exec.doneChan
+		if exec.pipeReader != nil {
+			_ = exec.pipeReader.Close()
+		}
+	}()
+}
+
+func (exec *Executor) openPipeWriter() {
+	var muFifo sync.Mutex
+	fifoOpened := false
+
+	go func() {
+		<-exec.doneChan
+		muFifo.Lock()
+		if !fifoOpened {
+			cleanupHandle(exec.namedPipeWriterHandle)
+		}
+		muFifo.Unlock()
+	}()
+
+	go func() {
+		klog.V(2).Infof("Connecting Windows named pipeWriter in %q", exec.namedPipeWriterPath)
+		if exec.isDone {
+			klog.Warningf("Connecting Windows NamedPipeWriter in %q failed, since program already stopped/crashed", exec.namedPipeWriterPath)
+			return
+		}
+		handle := windows.Handle(exec.namedPipeWriterHandle)
+		err := windows.ConnectNamedPipe(handle, nil)
+		if err != nil && err != windows.ERROR_PIPE_CONNECTED {
+			klog.Warningf("Failed to connect Windows named pipe %q for writing: %+v", exec.namedPipeWriterPath, err)
+			return
+		}
+		klog.V(2).Infof("Connected Windows named pipeWriter in %q", exec.namedPipeWriterPath)
+		f := os.NewFile(exec.namedPipeWriterHandle, exec.namedPipeWriterPath)
+		muFifo.Lock()
+		exec.pipeWriter = f
+		fifoOpened = true
+		defer muFifo.Unlock()
+
+		go exec.pollPipeWriterFifo()
+
+		<-exec.doneChan
+		close(exec.PipeWriterFifo)
+		if exec.pipeWriter != nil {
+			_ = exec.pipeWriter.Close()
+		}
+	}()
+}

--- a/internal/kernel/install.go
+++ b/internal/kernel/install.go
@@ -63,6 +63,9 @@ func Install(extraArgs []string, forceDeps, forceCopy bool) error {
 
 	// Jupyter configuration directory for gonb.
 	home := os.Getenv("HOME")
+	if home == "" {
+		home = os.Getenv("USERPROFILE")
+	}
 	jupyterDataDir := os.Getenv(JupyterDataDirEnv)
 	if jupyterDataDir == "" {
 		switch runtime.GOOS {
@@ -70,6 +73,12 @@ func Install(extraArgs []string, forceDeps, forceCopy bool) error {
 			jupyterDataDir = path.Join(home, ".local/share/jupyter")
 		case "darwin":
 			jupyterDataDir = path.Join(home, "Library/Jupyter")
+		case "windows":
+			appData := os.Getenv("APPDATA")
+			if appData == "" {
+				appData = path.Join(home, "AppData", "Roaming")
+			}
+			jupyterDataDir = path.Join(appData, "jupyter")
 		default:
 			return errors.Errorf("Unknown OS %q: not sure where to install GoNB kernel -- set the environment %q to force a location.", runtime.GOOS, JupyterDataDirEnv)
 		}
@@ -83,11 +92,16 @@ func Install(extraArgs []string, forceDeps, forceCopy bool) error {
 	// of Go binary. We then make a copy of the binary (since it will be deleted) to the configuration
 	// directory -- otherwise we just point to the current binary.
 	cacheDir, cacheErr := os.UserCacheDir()
+	tmpDir := os.TempDir()
 	if forceCopy ||
 		strings.HasPrefix(os.Args[0], "/tmp/") ||
 		strings.HasPrefix(os.Args[0], "/var/folders") ||
+		(tmpDir != "" && strings.HasPrefix(os.Args[0], tmpDir)) ||
 		(cacheErr == nil && strings.HasPrefix(os.Args[0], cacheDir)) {
 		newBinary := path.Join(kernelDir, "gonb")
+		if runtime.GOOS == "windows" {
+			newBinary = path.Join(kernelDir, "gonb.exe")
+		}
 		// Move the previous version out of the way.
 		if _, err := os.Stat(newBinary); err == nil {
 			err = os.Rename(newBinary, newBinary+"~")

--- a/internal/specialcmd/specialcmd.go
+++ b/internal/specialcmd/specialcmd.go
@@ -11,6 +11,7 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 
@@ -338,32 +339,38 @@ func execSpecialConfig(msg kernel.Message, goExec *goexec.State, cmdStr string, 
 	return nil
 }
 
+// shellCommand returns the OS shell and its command flag for executing a command string.
+func shellCommand() (shell string, argFlag string) {
+	if runtime.GOOS == "windows" {
+		return "cmd.exe", "/c"
+	}
+	return "/bin/bash", "-c"
+}
+
 // execShell executes `cmdStr` properly redirecting outputs to display in the notebook.
 //
 // It only returns errors for system errors that will lead to the kernel restart. Syntax errors
 // on the command themselves are simply reported back to jupyter and are not returned here.
 func execShell(msg kernel.Message, goExec *goexec.State, cmdStr string, status *cellStatus) error {
-	var execDir string // Default "", means current directory.
+	var execDir string
 	if cmdStr[0] == '*' {
 		cmdStr = cmdStr[1:]
 		execDir = goExec.TempDir
 	}
+	shell, argFlag := shellCommand()
+	execBase := jpyexec.New(msg, shell, argFlag, cmdStr).
+			ExecutionCount(msg.Kernel().ExecCounter).
+			InDir(execDir)
 	if status.withInputs {
 		status.withInputs = false
 		status.withPassword = false
-		return jpyexec.New(msg, "/bin/bash", "-c", cmdStr).
-			ExecutionCount(msg.Kernel().ExecCounter).
-			InDir(execDir).WithInputs(MillisecondsWaitForInput).Exec()
+		return execBase.WithInputs(MillisecondsWaitForInput).Exec()
 	} else if status.withPassword {
 		status.withInputs = false
 		status.withPassword = false
-		return jpyexec.New(msg, "/bin/bash", "-c", cmdStr).
-			ExecutionCount(msg.Kernel().ExecCounter).
-			InDir(execDir).WithPassword(MillisecondsWaitForInput).Exec()
+		return execBase.WithPassword(MillisecondsWaitForInput).Exec()
 	} else {
-		return jpyexec.New(msg, "/bin/bash", "-c", cmdStr).
-			ExecutionCount(msg.Kernel().ExecCounter).
-			InDir(execDir).Exec()
+		return execBase.Exec()
 	}
 }
 


### PR DESCRIPTION
Add native Windows support (not WSL) for gonb, allowing Windows users to use it directly without the need for Docker or WSL. 

NamedPipes: The `namedpipes.go` file has been split into a platform-independent dispatch layer, as well as two sets of implementations for Unix FIFO and Windows named pipes (`\\.\pipe\gonb_xxx`). The client `gonbui` does not need to be modified. 

ProcessManagement: Remove the Unix-specific `syscall.SIGKILL` and replace it with the cross-platform `cmd.Process.Kill()`. 

CompilationResult: Automatically adds the `.exe` extension on Windows. 

Process CWD query: On Windows, the actual working directory is obtained using `NtQueryInformationProcess`, and if the query fails, the directory where the executable file is located is used as a fallback. 

ShellCommand: On Windows, use `cmd.exe /c` instead. 
GoplsCompatibility: On Windows, use TCP addresses instead of Unix sockets.

It should be noted that, due to the limited number of machines I have at my disposal, I am unable to determine whether certain actions have had any impact on the behavior of other platforms.

Here is an example picture:
<img width="286" height="385" alt="image" src="https://github.com/user-attachments/assets/4ba36abc-9b65-42cf-99e4-4a4d21b24c6f" />

